### PR TITLE
Fix for custom network configuration in encode/decode

### DIFF
--- a/src/commands/decode.ts
+++ b/src/commands/decode.ts
@@ -34,9 +34,14 @@ export function registerDecodeCommand(program: Command) {
         throw new Error('When using a "custom" network, you must provide a --fullnode URL.');
       }
     })
-    .action(async (options: { bytes: string; network: Network }) => {
+    .action(async (options: { bytes: string; network: Network; fullnode: string }) => {
       const network = await ensureNetworkExists(options.network);
-      const aptos = new Aptos(new AptosConfig({ network }));
+      const aptos = new Aptos(
+        new AptosConfig({
+          network,
+          ...(options.fullnode && { fullnode: options.fullnode }),
+        })
+      );
 
       try {
         console.log(chalk.blue(`Decoding multisig payload: ${options.bytes}`));

--- a/src/commands/encode.ts
+++ b/src/commands/encode.ts
@@ -32,10 +32,14 @@ export function registerEncodeCommand(program: Command) {
         throw new Error('When using a "custom" network, you must provide a --fullnode URL.');
       }
     })
-    .action(async (options: { txnPayloadFile: string; network: Network }) => {
+    .action(async (options: { txnPayloadFile: string; network: Network; fullnode: string }) => {
       const network = await ensureNetworkExists(options.network);
-      const aptos = new Aptos(new AptosConfig({ network }));
-
+      const aptos = new Aptos(
+        new AptosConfig({
+          network,
+          ...(options.fullnode && { fullnode: options.fullnode }),
+        })
+      );
       try {
         console.log(chalk.blue(`Encoding transaction payload: ${options.txnPayloadFile}`));
         // TODO: verify the file is a valid json with function_id, type_args, and args


### PR DESCRIPTION
When using a custom network with the decode command, the fullnode URL was being collected as a command-line parameter but wasn't properly passed to the AptosConfig object, causing the custom network configuration to be incomplete.

Error message when trying to decode a payload on Movement mainnet (custom network:
```
$ safely decode -b 0x000000000000000000000000000000000000000000000000000000000000000001106d756c74697369675f6163636f756e742a737761705f6f776e6572735f616e645f7570646174655f7369676e6174757265735f726571756972656400032101434e1d2ba65e12b43d1b78bd2f7dbeba2ec92126b20c5d347ba55e20f1e804e50100080100000000000000 --network custom --fullnode https://mainnet.movementnetwork.xyz/v1
Decoding multisig payload: 0x000000000000000000000000000000000000000000000000000000000000000001106d756c74697369675f6163636f756e742a737761705f6f776e6572735f616e645f7570646174655f7369676e6174757265735f726571756972656400032101434e1d2ba65e12b43d1b78bd2f7dbeba2ec92126b20c5d347ba55e20f1e804e50100080100000000000000
Error: Please provide a custom full node url
```

After implementing the fix:
```
$ safely decode -b 0x000000000000000000000000000000000000000000000000000000000000000001106d756c74697369675f6163636f756e742a737761705f6f776e6572735f616e645f7570646174655f7369676e6174757265735f726571756972656400032101434e1d2ba65e12b43d1b78bd2f7dbeba2ec92126b20c5d347ba55e20f1e804e50100080100000000000000 --network custom --fullnode https://mainnet.movementnetwork.xyz/v1
Decoding multisig payload: 0x000000000000000000000000000000000000000000000000000000000000000001106d756c74697369675f6163636f756e742a737761705f6f776e6572735f616e645f7570646174655f7369676e6174757265735f726571756972656400032101434e1d2ba65e12b43d1b78bd2f7dbeba2ec92126b20c5d347ba55e20f1e804e50100080100000000000000
{
  function: '0x1::multisig_account::swap_owners_and_update_signatures_required',
  typeArguments: [],
  functionArguments: [ [ [e] ], [], 1n ]
}
```

Note: I noticed the same configuration was missing for encode. I also implemented the fix for encode, but did not test that.