### PR TITLE
skip simulation error on movement submit

### DIFF
--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -127,7 +127,7 @@ export async function fetchPendingTxns(
     payloadsDecoded.map(async (p) => {
       if ('error' in p) {
         // If the payload decoding failed, return a placeholder entry
-        return
+        return;
       }
 
       try {


### PR DESCRIPTION
skip this error

```
Error: Request to [Fullnode]: POST https://mainnet.movementnetwork.xyz/v1/transactions/simulate failed with: {"message":"Failed to deserialize input into SignedTransaction: invalid value: integer `4`, expected variant index 0 <= i < 4","error_code":"invalid_input","vm_error_code":null}
```