### PR TITLE
feat: add multi-chain support for Movement network

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -7,7 +7,8 @@ Options:
   -h, --help        display help for command
 Commands:
   create [options]  Create a new multisig account
-  update [options]  Update multisig owners and optionally the number of required signatures
+  update [options]  Update multisig owners and optionally the number of
+                    required signatures
   show [options]    Show multisig summary
   help [command]    display help for command
 ```
@@ -21,6 +22,7 @@ Options:
   -o, --additional-owners <addresses>     Comma-separated list of additional owner addresses
   -n, --num-signatures-required <number>  Number of signatures required for execution
   -p, --profile <string>                  Profile to use for the transaction
+  --network <network>                     network to use (choices: "aptos-devnet", "aptos-testnet", "aptos-mainnet", "movement-mainnet", "movement-testnet", "custom")
   -h, --help                              display help for command
 ```
 
@@ -35,6 +37,7 @@ Options:
   -r, --owners-remove <addresses>         Comma-separated list of owner addresses to remove
   -n, --num-signatures-required <number>  New number of signatures required for execution
   -p, --profile <string>                  Profile to use for the transaction
+  --network <network>                     network to use (choices: "aptos-devnet", "aptos-testnet", "aptos-mainnet", "movement-mainnet", "movement-testnet", "custom")
   -h, --help                              display help for command
 ```
 
@@ -45,7 +48,10 @@ Show multisig summary
 ```
 Options:
   -m, --multisig-address <address>  multisig account address
-  --network <network>               network to use (choices: "devnet", "testnet", "mainnet", "custom")
+  --network <network>               network to use (choices: "aptos-devnet",
+                                    "aptos-testnet", "aptos-mainnet",
+                                    "movement-mainnet", "movement-testnet",
+                                    "custom")
   --fullnode <url>                  Fullnode URL for custom network
   -h, --help                        display help for command
 ```
@@ -61,7 +67,8 @@ Options:
   -p, --profile <string>            Profile to use for the transaction
   -h, --help                        display help for command
 Commands:
-  raw [options]                     Propose a raw transaction from a payload file
+  raw [options]                     Propose a raw transaction from a payload
+                                    file
   predefined                        Propose a predefined transaction type
   help [command]                    display help for command
 ```
@@ -121,6 +128,10 @@ Execute a multisig transaction
 Options:
   -m, --multisig-address <address>  multisig account address
   -p, --profile <string>            Profile to use for the transaction
+  --network <network>               network to use (choices: "aptos-devnet",
+                                    "aptos-testnet", "aptos-mainnet",
+                                    "movement-mainnet", "movement-testnet",
+                                    "custom")
   -h, --help                        display help for command
 ```
 
@@ -131,12 +142,18 @@ List proposals for a multisig
 ```
 Options:
   -m, --multisig-address <address>  multisig account address
-  --network <network>               network to use (choices: "devnet", "testnet", "mainnet", "custom")
+  --network <network>               network to use (choices: "aptos-devnet",
+                                    "aptos-testnet", "aptos-mainnet",
+                                    "movement-mainnet", "movement-testnet",
+                                    "custom")
   --fullnode <url>                  Fullnode URL for custom network
-  -f, --filter <status>             filter proposals by status (default: "pending")
-  -s, --sequence-number <number>    fetch transaction with specific sequence number
+  -f, --filter <status>             filter proposals by status (default:
+                                    "pending")
+  -s, --sequence-number <number>    fetch transaction with specific sequence
+                                    number
   -p, --profile <string>            Profile to use for the transaction
-  -l, --limit <number>              number of transactions to fetch (default: 20)
+  -l, --limit <number>              number of transactions to fetch (default:
+                                    20)
   -h, --help                        display help for command
 ```
 
@@ -147,9 +164,13 @@ Simulate multisig transaction
 ```
 Options:
   -m, --multisig-address <address>  multisig account address
-  --network <network>               network to use (choices: "devnet", "testnet", "mainnet", "custom")
+  --network <network>               network to use (choices: "aptos-devnet",
+                                    "aptos-testnet", "aptos-mainnet",
+                                    "movement-mainnet", "movement-testnet",
+                                    "custom")
   --fullnode <url>                  Fullnode URL for custom network
-  -s, --sequence-number <number>    fetch transaction with specific sequence number
+  -s, --sequence-number <number>    fetch transaction with specific sequence
+                                    number
   -h, --help                        display help for command
 ```
 
@@ -159,8 +180,11 @@ Decode multisig transaction bytes (experimental)
 
 ```
 Options:
-  -b, --bytes <bytes>  transaction bytes to decode (hex string starting with 0x)
-  --network <network>  network to use (choices: "devnet", "testnet", "mainnet", "custom")
+  -b, --bytes <bytes>  transaction bytes to decode (hex string starting with
+                       0x)
+  --network <network>  network to use (choices: "aptos-devnet",
+                       "aptos-testnet", "aptos-mainnet", "movement-mainnet",
+                       "movement-testnet", "custom")
   --fullnode <url>     Fullnode URL for custom network
   -h, --help           display help for command
 ```
@@ -172,7 +196,7 @@ Encode entry function payload (experimental)
 ```
 Options:
   -f, --txn-payload-file <txn-payload-file>  transaction payload file to encode
-  --network <network>                        network to use (choices: "devnet", "testnet", "mainnet", "custom")
+  --network <network>                        network to use (choices: "aptos-devnet", "aptos-testnet", "aptos-mainnet", "movement-mainnet", "movement-testnet", "custom")
   --fullnode <url>                           Fullnode URL for custom network
   -h, --help                                 display help for command
 ```
@@ -251,7 +275,9 @@ Set default multisig values
 ```
 Options:
   -m, --multisig <address>  Multisig address
-  -n, --network <network>   network to use (choices: "devnet", "testnet", "mainnet", "custom")
+  -n, --network <network>   network to use (choices: "aptos-devnet",
+                            "aptos-testnet", "aptos-mainnet",
+                            "movement-mainnet", "movement-testnet", "custom")
   -p, --profile <string>    Profile to use for transactions
   -h, --help                display help for command
 ```

--- a/src/commands/decode.ts
+++ b/src/commands/decode.ts
@@ -1,8 +1,10 @@
 import { Command, Option } from 'commander';
-import { Aptos, AptosConfig, Network } from '@aptos-labs/ts-sdk';
+import { Aptos, AptosConfig } from '@aptos-labs/ts-sdk';
 import chalk from 'chalk';
 import { decode } from '@thalalabs/multisig-utils';
 import { ensureNetworkExists } from '../storage.js';
+import { NETWORK_CHOICES, NetworkChoice } from '../constants.js';
+import { getFullnodeUrl } from '../utils.js';
 
 export function registerDecodeCommand(program: Command) {
   program
@@ -20,12 +22,7 @@ export function registerDecodeCommand(program: Command) {
       }
     )
     .addOption(
-      new Option('--network <network>', 'network to use').choices([
-        'devnet',
-        'testnet',
-        'mainnet',
-        'custom',
-      ])
+      new Option('--network <network>', 'network to use').choices(NETWORK_CHOICES)
     )
     .addOption(new Option('--fullnode <url>', 'Fullnode URL for custom network'))
     .hook('preAction', (thisCommand) => {
@@ -34,12 +31,11 @@ export function registerDecodeCommand(program: Command) {
         throw new Error('When using a "custom" network, you must provide a --fullnode URL.');
       }
     })
-    .action(async (options: { bytes: string; network: Network; fullnode: string }) => {
+    .action(async (options: { bytes: string; network: NetworkChoice; fullnode: string }) => {
       const network = await ensureNetworkExists(options.network);
       const aptos = new Aptos(
         new AptosConfig({
-          network,
-          ...(options.fullnode && { fullnode: options.fullnode }),
+          fullnode: options.fullnode || getFullnodeUrl(network),
         })
       );
 

--- a/src/commands/defaults.ts
+++ b/src/commands/defaults.ts
@@ -2,6 +2,7 @@ import { Command, Option } from 'commander';
 import { MultisigDefault, NetworkDefault, ProfileDefault } from '../storage.js';
 import chalk from 'chalk';
 import { validateAddress } from '../validators.js';
+import { NETWORK_CHOICES } from '../constants.js';
 
 export const registerDefaultCommand = (program: Command) => {
   const defaults = program.command('default').description('Multisig default values');
@@ -27,12 +28,7 @@ export const registerDefaultCommand = (program: Command) => {
     .description('Set default multisig values')
     .option('-m, --multisig <address>', 'Multisig address', validateAddress)
     .addOption(
-      new Option('-n, --network <network>', 'network to use').choices([
-        'devnet',
-        'testnet',
-        'mainnet',
-        'custom',
-      ])
+      new Option('-n, --network <network>', 'network to use').choices(NETWORK_CHOICES)
     )
     .option('-p, --profile <string>', 'Profile to use for transactions')
     .action(async (opts) => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,10 @@
+export const NETWORK_CHOICES = [
+  'aptos-devnet',
+  'aptos-testnet',  
+  'aptos-mainnet',
+  'movement-mainnet',
+  'movement-testnet',
+  'custom',
+] as const;
+
+export type NetworkChoice = typeof NETWORK_CHOICES[number];

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,6 +1,6 @@
 import { Low } from 'lowdb';
 import { JSONFilePreset } from 'lowdb/node';
-import { Network } from '@aptos-labs/ts-sdk';
+import { NetworkChoice } from './constants.js';
 
 type Address = {
   alias: string;
@@ -10,7 +10,7 @@ type Address = {
 type SafelyStorage = {
   addresses: Address[];
   multisig?: string;
-  network?: Network;
+  network?: NetworkChoice;
   profile?: string;
 };
 
@@ -93,7 +93,7 @@ export const MultisigDefault = {
 
 // **Network Default**
 export const NetworkDefault = {
-  async set(network: Network) {
+  async set(network: NetworkChoice) {
     await writeDb((db) => {
       db.network = network;
     });
@@ -107,7 +107,7 @@ export const NetworkDefault = {
     });
   },
 
-  async get(): Promise<Network | undefined> {
+  async get(): Promise<NetworkChoice | undefined> {
     return readDb((db) => db.network);
   },
 };
@@ -147,13 +147,13 @@ export async function ensureMultisigAddressExists(multisigAddressOption?: string
   return storedAddress;
 }
 
-export async function ensureNetworkExists(networkOption?: Network): Promise<Network> {
+export async function ensureNetworkExists(networkOption?: NetworkChoice): Promise<NetworkChoice> {
   if (networkOption) {
     return networkOption;
   }
 
   const storedNetwork = await NetworkDefault.get();
-  return storedNetwork ? storedNetwork : Network.MAINNET;
+  return storedNetwork ? storedNetwork : 'aptos-mainnet';
 }
 
 export async function ensureProfileExists(profileOption?: string): Promise<string> {

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -1,4 +1,6 @@
 import { AddressBook, getDb } from './storage.js';
+import { NetworkChoice } from './constants.js';
+import { getExplorerUrl } from './utils.js';
 import {
   Account,
   Aptos,
@@ -43,6 +45,7 @@ export async function proposeEntryFunction(
   signer: Account | LedgerSigner,
   entryFunction: InputEntryFunctionData,
   multisigAddress: string,
+  network: NetworkChoice,
   simulate = true
 ) {
   // Fetch ABI
@@ -126,13 +129,13 @@ export async function proposeEntryFunction(
   if (success) {
     console.log(
       chalk.green(
-        `Propose ok: https://explorer.aptoslabs.com/txn/${pendingTxn.hash}?network=${aptos.config.network}`
+        `Propose ok: ${getExplorerUrl(network, `txn/${pendingTxn.hash}`)}`
       )
     );
   } else {
     console.log(
       chalk.red(
-        `Propose nok ${vm_status}: https://explorer.aptoslabs.com/txn/${pendingTxn.hash}?network=${aptos.config.network}`
+        `Propose nok ${vm_status}: ${getExplorerUrl(network, `txn/${pendingTxn.hash}`)}`
       )
     );
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,18 +1,53 @@
-import { Network } from '@aptos-labs/ts-sdk';
+import { NetworkChoice } from './constants.js';
 
-export function getFullnodeUrl(network: Network): string {
+export function getFullnodeUrl(network: NetworkChoice): string {
   switch (network) {
-    case Network.MAINNET:
+    case 'aptos-mainnet':
       return 'https://api.mainnet.aptoslabs.com/v1';
-    case Network.TESTNET:
+    case 'aptos-testnet':
       return 'https://api.testnet.aptoslabs.com/v1';
-    case Network.DEVNET:
+    case 'aptos-devnet':
       return 'https://api.devnet.aptoslabs.com/v1';
-    case Network.LOCAL:
-      return 'http://127.0.0.1:8080/v1';
-    case Network.CUSTOM:
+    case 'movement-mainnet':
+      return 'https://full.mainnet.movementinfra.xyz/v1';
+    case 'movement-testnet':
+      return 'https://full.testnet.movementinfra.xyz/v1';
+    case 'custom':
       throw new Error('Custom network requires an explicit fullnode URL');
     default:
       throw new Error(`Unknown network: ${network}`);
   }
 }
+
+export function getConfigPath(network: NetworkChoice): string {
+  if (network === 'movement-mainnet' || network === 'movement-testnet') {
+    return '.movement/config.yaml';
+  }
+  return '.aptos/config.yaml';
+}
+
+export function getExplorerUrl(network: NetworkChoice, path: string): string {
+  const networkParam = (() => {
+    switch (network) {
+      case 'aptos-mainnet':
+        return 'mainnet';
+      case 'aptos-testnet':
+        return 'testnet';
+      case 'aptos-devnet':
+        return 'devnet';
+      case 'movement-mainnet':
+        return 'mainnet';
+      case 'movement-testnet':
+        return 'testnet';
+      default:
+        return 'custom';
+    }
+  })();
+
+  if (network === 'movement-mainnet' || network === 'movement-testnet') {
+    return `https://explorer.movementlabs.xyz/${path}?network=${networkParam}`;
+  }
+  
+  return `https://explorer.aptoslabs.com/${path}?network=${networkParam}`;
+}
+


### PR DESCRIPTION
fix #126 
- Extend network choices to include movement-mainnet and movement-testnet
- Prefix existing networks with 'aptos-' for clarity (breaking change)
- Add getConfigPath() to load profiles from .movement/config.yaml for Movement networks
- Add getExplorerUrl() to support chain-specific explorer URLs
- Update loadProfile() to require network parameter for proper config file selection
- Movement networks use different fullnode URLs without /v1 suffix
- Replace all hardcoded explorer URLs with getExplorerUrl() calls
- Remove dependency on Aptos SDK Network enum in favor of custom NetworkChoice type

BREAKING CHANGE: Network values now require 'aptos-' prefix (e.g., 'mainnet' -> 'aptos-mainnet')