### PR TITLE
feat: replace -f option with --payload supporting file, JSON string, and stdin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,81 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Common Development Commands
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build the project
+pnpm build
+
+# Run in development mode (auto-restarts)
+pnpm start
+
+# Format code with Prettier
+pnpm format
+
+# Generate documentation from CLI commands
+pnpm docgen
+
+# Link for local testing
+pnpm link -g
+
+# Run E2E tests
+bash tests/e2e/run.sh
+```
+
+## High-Level Architecture
+
+### Core Structure
+
+The project is a CLI tool for managing Aptos/Movement multisig accounts, built with TypeScript and Commander.js.
+
+1. **Entry Point**: `src/index.ts` - Registers all commands and initializes the CLI
+2. **Commands**: `src/commands/` - Each file implements a specific CLI command
+
+   - `account.ts` - Multisig account creation, updates, and info
+   - `propose.ts` - Submit new transactions to multisigs
+   - `vote.ts` - Vote on pending transactions
+   - `execute.ts` - Execute approved transactions
+   - `proposal.ts` - List and view pending proposals
+   - `simulate.ts` - Simulate transactions before execution
+
+3. **Core Modules**:
+
+   - `transactions.ts` - Transaction building, simulation, and submission logic
+   - `signing.ts` - Handles transaction signing with Account or Ledger
+   - `storage.ts` - Local database for address book and defaults (using lowdb)
+   - `utils.ts` - Network configuration, explorer URLs, and helpers
+   - `validators.ts` - Input validation functions
+   - `entryFunction.ts` - Handles ABI decoding and display
+
+4. **Ledger Integration**: `src/ledger/` - Hardware wallet support
+   - `LedgerSigner.ts` - Custom signer implementation
+   - `AptosLedgerClient.ts` - Low-level Ledger communication
+
+### Key Design Patterns
+
+1. **Network Abstraction**: Supports multiple networks (Aptos mainnet/testnet/devnet, Movement mainnet/testnet) with custom fullnode URLs
+2. **Profile System**: Integrates with Aptos CLI profiles for key management
+3. **Interactive UI**: Uses @inquirer/prompts for user-friendly terminal interactions
+4. **Transaction Safety**: Always simulates transactions before proposing/executing
+5. **Readable Output**: Uses chalk for colored output and cli-table3 for formatted data
+
+### Dependencies
+
+- `@aptos-labs/ts-sdk` - Aptos blockchain interaction
+- `@thalalabs/multisig-utils` - Multisig-specific utilities
+- `commander` - CLI framework
+- `@inquirer/prompts` - Interactive prompts
+- `@ledgerhq/*` - Ledger hardware wallet support
+
+## Development Tips
+
+- TypeScript strict mode is enabled - ensure proper type annotations
+- The project uses ES modules (type: "module" in package.json)
+- Node.js >=20 and pnpm >=9 are required
+- When adding new commands, register them in `src/index.ts`
+- Transaction simulation is critical for safety - respect the `--ignore-simulate` flag carefully

--- a/docs.md
+++ b/docs.md
@@ -32,10 +32,10 @@ Update multisig owners and optionally the number of required signatures
 
 ```
 Options:
-  -m, --multisig-address <address>        multisig account address
   -a, --owners-add <addresses>            Comma-separated list of owner addresses to add
   -r, --owners-remove <addresses>         Comma-separated list of owner addresses to remove
   -n, --num-signatures-required <number>  New number of signatures required for execution
+  -m, --multisig-address <address>        multisig account address
   -p, --profile <string>                  Profile to use for the transaction
   --network <network>                     network to use (choices: "aptos-devnet", "aptos-testnet", "aptos-mainnet", "movement-mainnet", "movement-testnet", "custom")
   -h, --help                              display help for command
@@ -63,8 +63,12 @@ Propose a new transaction for a multisig
 ```
 Options:
   -m, --multisig-address <address>  multisig account address
-  --ignore-simulate <boolean>       ignore tx simulation (default: false)
+  --network <network>               network to use (choices: "aptos-devnet",
+                                    "aptos-testnet", "aptos-mainnet",
+                                    "movement-mainnet", "movement-testnet",
+                                    "custom")
   -p, --profile <string>            Profile to use for the transaction
+  --ignore-simulate <boolean>       ignore tx simulation (default: false)
   -h, --help                        display help for command
 Commands:
   raw [options]                     Propose a raw transaction from a payload
@@ -79,8 +83,23 @@ Propose a raw transaction from a payload file
 
 ```
 Options:
-  -f, --txn-payload-file <file>  Path to the transaction payload file
-  -h, --help                     display help for command
+  --payload <payload>  Transaction payload (file path, JSON string, or - for
+                       stdin)
+  -h, --help           display help for command
+```
+
+### Examples:
+
+```bash
+# From file
+safely propose raw --payload payload.json
+
+# Direct JSON string
+safely propose raw --payload '{"function_id":"0x1::coin::transfer","type_args":["0x1::aptos_coin::AptosCoin"],"args":[{"type":"address","value":"0x123"},{"type":"u64","value":1000}]}'
+
+# From stdin
+echo '{"function_id":"0x1::coin::transfer","type_args":["0x1::aptos_coin::AptosCoin"],"args":[{"type":"address","value":"0x123"},{"type":"u64","value":1000}]}' | safely propose raw --payload -
+cat payload.json | safely propose raw --payload -
 ```
 
 ## safely propose predefined [options] [command]
@@ -113,9 +132,13 @@ Vote on a pending transaction
 
 ```
 Options:
-  -m, --multisig-address <address>  multisig account address
   -s, --sequence-number <number>    sequence number of transaction to vote on
   -a, --approve <boolean>           true to approve, false to reject
+  -m, --multisig-address <address>  multisig account address
+  --network <network>               network to use (choices: "aptos-devnet",
+                                    "aptos-testnet", "aptos-mainnet",
+                                    "movement-mainnet", "movement-testnet",
+                                    "custom")
   -p, --profile <string>            profile name of voter
   -h, --help                        display help for command
 ```
@@ -195,10 +218,13 @@ Encode entry function payload (experimental)
 
 ```
 Options:
-  -f, --txn-payload-file <txn-payload-file>  transaction payload file to encode
-  --network <network>                        network to use (choices: "aptos-devnet", "aptos-testnet", "aptos-mainnet", "movement-mainnet", "movement-testnet", "custom")
-  --fullnode <url>                           Fullnode URL for custom network
-  -h, --help                                 display help for command
+  --payload <payload>  Transaction payload (file path, JSON string, or - for
+                       stdin)
+  --network <network>  network to use (choices: "aptos-devnet",
+                       "aptos-testnet", "aptos-mainnet", "movement-mainnet",
+                       "movement-testnet", "custom")
+  --fullnode <url>     Fullnode URL for custom network
+  -h, --help           display help for command
 ```
 
 ## safely addresses [options] [command]

--- a/docs.md
+++ b/docs.md
@@ -88,20 +88,6 @@ Options:
   -h, --help           display help for command
 ```
 
-### Examples:
-
-```bash
-# From file
-safely propose raw --payload payload.json
-
-# Direct JSON string
-safely propose raw --payload '{"function_id":"0x1::coin::transfer","type_args":["0x1::aptos_coin::AptosCoin"],"args":[{"type":"address","value":"0x123"},{"type":"u64","value":1000}]}'
-
-# From stdin
-echo '{"function_id":"0x1::coin::transfer","type_args":["0x1::aptos_coin::AptosCoin"],"args":[{"type":"address","value":"0x123"},{"type":"u64","value":1000}]}' | safely propose raw --payload -
-cat payload.json | safely propose raw --payload -
-```
-
 ## safely propose predefined [options] [command]
 
 Propose a predefined transaction type

--- a/src/commands/encode.ts
+++ b/src/commands/encode.ts
@@ -1,23 +1,18 @@
-import * as fs from 'node:fs';
 import { Command, Option } from 'commander';
 import { Aptos, AptosConfig } from '@aptos-labs/ts-sdk';
 import chalk from 'chalk';
 import { encode } from '@thalalabs/multisig-utils';
 import { ensureNetworkExists } from '../storage.js';
 import { NETWORK_CHOICES, NetworkChoice } from '../constants.js';
-import { getFullnodeUrl } from '../utils.js';
+import { getFullnodeUrl, resolvePayloadInput } from '../utils.js';
 
 export function registerEncodeCommand(program: Command) {
   program
     .command('encode')
     .description('Encode entry function payload (experimental)')
     .requiredOption(
-      '-f, --txn-payload-file <txn-payload-file>',
-      'transaction payload file to encode',
-      (value) => {
-        // TODO: validate file exists
-        return value;
-      }
+      '--payload <payload>',
+      'Transaction payload (file path, JSON string, or - for stdin)'
     )
     .addOption(new Option('--network <network>', 'network to use').choices(NETWORK_CHOICES))
     .addOption(new Option('--fullnode <url>', 'Fullnode URL for custom network'))
@@ -27,26 +22,24 @@ export function registerEncodeCommand(program: Command) {
         throw new Error('When using a "custom" network, you must provide a --fullnode URL.');
       }
     })
-    .action(
-      async (options: { txnPayloadFile: string; network: NetworkChoice; fullnode: string }) => {
-        const network = await ensureNetworkExists(options.network);
-        const aptos = new Aptos(
-          new AptosConfig({
-            fullnode: options.fullnode || getFullnodeUrl(network),
-          })
+    .action(async (options: { payload: string; network: NetworkChoice; fullnode: string }) => {
+      const network = await ensureNetworkExists(options.network);
+      const aptos = new Aptos(
+        new AptosConfig({
+          fullnode: options.fullnode || getFullnodeUrl(network),
+        })
+      );
+      try {
+        console.log(chalk.blue(`Encoding transaction payload...`));
+        const jsonContent = await resolvePayloadInput(options.payload);
+        const txnPayload = JSON.parse(jsonContent);
+        console.log(
+          (
+            await encode(aptos, txnPayload.function_id, txnPayload.type_args, txnPayload.args)
+          ).toString()
         );
-        try {
-          console.log(chalk.blue(`Encoding transaction payload: ${options.txnPayloadFile}`));
-          // TODO: verify the file is a valid json with function_id, type_args, and args
-          const txnPayload = JSON.parse(fs.readFileSync(options.txnPayloadFile, 'utf8'));
-          console.log(
-            (
-              await encode(aptos, txnPayload.function_id, txnPayload.type_args, txnPayload.args)
-            ).toString()
-          );
-        } catch (error) {
-          console.error(chalk.red(`Error: ${(error as Error).message}`));
-        }
+      } catch (error) {
+        console.error(chalk.red(`Error: ${(error as Error).message}`));
       }
-    );
+    });
 }

--- a/src/commands/encode.ts
+++ b/src/commands/encode.ts
@@ -16,6 +16,19 @@ export function registerEncodeCommand(program: Command) {
     )
     .addOption(new Option('--network <network>', 'network to use').choices(NETWORK_CHOICES))
     .addOption(new Option('--fullnode <url>', 'Fullnode URL for custom network'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  # From file
+  $ safely encode --payload payload.json --network aptos-testnet
+  
+  # Direct JSON string
+  $ safely encode --payload '{"function_id":"0x1::coin::transfer","type_args":["0x1::aptos_coin::AptosCoin"],"args":["0x123",1000]}' --network aptos-testnet
+  
+  # From stdin
+  $ echo '{"function_id":"0x1::coin::transfer","type_args":["0x1::aptos_coin::AptosCoin"],"args":["0x123",1000]}' | safely encode --payload - --network aptos-testnet`
+    )
     .hook('preAction', (thisCommand) => {
       const options = thisCommand.opts();
       if (options.network === 'custom' && !options.fullnode) {

--- a/src/commands/propose.ts
+++ b/src/commands/propose.ts
@@ -30,6 +30,20 @@ export const registerProposeCommand = (program: Command) => {
       '--payload <payload>',
       'Transaction payload (file path, JSON string, or - for stdin)'
     )
+    .addHelpText(
+      'after',
+      `
+Examples:
+  # From file
+  $ safely propose raw --payload payload.json
+  
+  # Direct JSON string
+  $ safely propose raw --payload '{"function_id":"0x1::coin::transfer","type_args":["0x1::aptos_coin::AptosCoin"],"args":["0x123",1000]}'
+  
+  # From stdin
+  $ echo '{"function_id":"0x1::coin::transfer","type_args":["0x1::aptos_coin::AptosCoin"],"args":["0x123",1000]}' | safely propose raw --payload -
+  $ cat payload.json | safely propose raw --payload -`
+    )
     .action(async (options: { payload: string }, cmd) => {
       const parentOptions = cmd.parent.opts();
       const multisig = await ensureMultisigAddressExists(parentOptions.multisigAddress);

--- a/src/entryFunction.ts
+++ b/src/entryFunction.ts
@@ -3,13 +3,11 @@ import {
   MoveFunctionId,
   SimpleEntryFunctionArgumentTypes,
 } from '@aptos-labs/ts-sdk';
-import * as fs from 'fs';
 
 export async function serializeEntryFunction(functionId: string) {}
 
-export function decodeEntryFunction(filePath: string): InputEntryFunctionData {
-  const file = fs.readFileSync(filePath, 'utf8');
-  const content = JSON.parse(file) as {
+export function parseEntryFunctionPayload(jsonContent: string): InputEntryFunctionData {
+  const content = JSON.parse(jsonContent) as {
     function_id: string;
     type_args: string[];
     args: Array<{ type: string; value: SimpleEntryFunctionArgumentTypes }>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,6 @@
 import { NetworkChoice } from './constants.js';
+import * as fs from 'fs';
+import * as path from 'path';
 
 export function getFullnodeUrl(network: NetworkChoice): string {
   switch (network) {
@@ -49,4 +51,35 @@ export function getExplorerUrl(network: NetworkChoice, path: string): string {
   }
 
   return `https://explorer.aptoslabs.com/${path}?network=${networkParam}`;
+}
+
+export async function resolvePayloadInput(payload: string): Promise<string> {
+  // Handle stdin
+  if (payload === '-') {
+    return readFromStdin();
+  }
+
+  // Check if it's a file
+  try {
+    const fullPath = path.resolve(payload);
+    if (fs.existsSync(fullPath)) {
+      return fs.readFileSync(fullPath, 'utf8');
+    }
+  } catch {
+    // If any error occurs checking file, treat as JSON string
+  }
+
+  // Return as-is (assume it's JSON string)
+  return payload;
+}
+
+async function readFromStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+
+    process.stdin.on('data', (chunk) => (data += chunk));
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
 }


### PR DESCRIPTION
## Summary
- Replace `-f, --txn-payload-file` with `--payload` option (no shortcut since `-p` is taken by `--profile`)
- Support three input methods for transaction payloads:
  - File path: `--payload payload.json`
  - Direct JSON string: `--payload '{"function_id":"..."}'`
  - Stdin: `--payload -` (e.g., `echo '...' | safely propose raw --payload -`)

## Changes
- Refactored `decodeEntryFunction` to `parseEntryFunctionPayload` that accepts JSON string instead of file path
- Added `resolvePayloadInput` utility function to handle payload resolution logic
- Updated both `propose raw` and `encode` commands to use the new option
- Added comprehensive examples to documentation

## Breaking Change
⚠️ The `-f` option is replaced with `--payload` option. Users need to update their scripts.

## Test plan
- [x] Tested file input: `safely encode --payload test-payload.json`
- [x] Tested JSON string input: `safely encode --payload '{"function_id":"..."}'`
- [x] Tested stdin input: `echo '...' | safely encode --payload -`
- [x] All three methods produce identical results
- [x] TypeScript compilation passes
- [x] Code formatted with prettier

🤖 Generated with [Claude Code](https://claude.ai/code)