### PR TITLE
feat: add batch payload support for propose raw command

### DIFF
--- a/src/entryFunction.ts
+++ b/src/entryFunction.ts
@@ -6,29 +6,77 @@ import {
 
 export async function serializeEntryFunction(functionId: string) {}
 
+export function isBatchPayload(jsonContent: string): boolean {
+  try {
+    const parsed = JSON.parse(jsonContent);
+    return Array.isArray(parsed);
+  } catch {
+    return false;
+  }
+}
+
+export function parseBatchPayload(jsonContent: string): InputEntryFunctionData[] {
+  const payloads = JSON.parse(jsonContent);
+  
+  if (!Array.isArray(payloads)) {
+    throw new Error('Batch payload must be an array');
+  }
+  
+  return payloads.map((payload, index) => {
+    try {
+      return parseSinglePayload(payload);
+    } catch (error) {
+      throw new Error(`Invalid payload at index ${index}: ${(error as Error).message}`);
+    }
+  });
+}
+
 export function parseEntryFunctionPayload(jsonContent: string): InputEntryFunctionData {
-  const content = JSON.parse(jsonContent) as {
-    function_id: string;
-    type_args: string[];
-    args: Array<{ type: string; value: SimpleEntryFunctionArgumentTypes }>;
-  };
+  const content = JSON.parse(jsonContent);
+  return parseSinglePayload(content);
+}
+
+function parseSinglePayload(content: {
+  function_id: string;
+  type_args: string[];
+  args: Array<{ type: string; value: SimpleEntryFunctionArgumentTypes } | SimpleEntryFunctionArgumentTypes>;
+}): InputEntryFunctionData {
+  // Validate required fields
+  if (!content.function_id) {
+    throw new Error('Missing required field: function_id');
+  }
+  if (!Array.isArray(content.type_args)) {
+    throw new Error('type_args must be an array');
+  }
+  if (!Array.isArray(content.args)) {
+    throw new Error('args must be an array');
+  }
 
   // Explicitly handle hex args (which must be cast to vector<u8> or vector<vector<u8>> types)
   const hexDecodedArgs = content.args.map((arg) => {
-    // Hex args need to be decoded into vector<u8> equivalents
-    if (arg.type === 'hex') {
-      // vector<u8>
-      if (typeof arg.value === 'string') {
-        return hexToBytes(arg.value);
-      }
+    // Handle both object format {type, value} and direct value format
+    if (typeof arg === 'object' && arg !== null && 'type' in arg && 'value' in arg) {
+      // Object format with type field
+      const typedArg = arg as { type: string; value: SimpleEntryFunctionArgumentTypes };
+      
+      // Hex args need to be decoded into vector<u8> equivalents
+      if (typedArg.type === 'hex') {
+        // vector<u8>
+        if (typeof typedArg.value === 'string') {
+          return hexToBytes(typedArg.value);
+        }
 
-      // vector<vector<u8>>
-      if (Array.isArray(arg.value) && arg.value.every((v) => typeof v === 'string')) {
-        return arg.value.map((hexStr) => hexToBytes(hexStr));
+        // vector<vector<u8>>
+        if (Array.isArray(typedArg.value) && typedArg.value.every((v) => typeof v === 'string')) {
+          return typedArg.value.map((hexStr) => hexToBytes(hexStr));
+        }
       }
+      
+      return typedArg.value;
     }
-
-    return arg.value;
+    
+    // Direct value format
+    return arg;
   });
 
   return {


### PR DESCRIPTION
## Summary
- Added support for batch payloads in `propose raw` command
- Auto-detects whether payload is single (object) or batch (array)
- Processes transactions sequentially with stop-on-failure behavior

## Features
- **Auto-detection**: Automatically detects single vs batch payloads
- **Sequential processing**: Proposes transactions one by one with progress indicators
- **Fail-fast**: Stops immediately if any transaction fails
- **Confirmation prompt**: Shows transaction count and asks for confirmation (skippable with `--yes`)
- **Backward compatible**: Single payload behavior unchanged

## Usage Examples
```bash
# Single payload (works as before)
$ safely propose raw --payload payload.json

# Batch payload with confirmation
$ safely propose raw --payload batch.json
> Found 3 transactions to propose. Continue? (Y/n)

# Batch payload auto-confirmed
$ safely propose raw --payload batch.json --yes
```

## Example Batch Payload
```json
[
  {
    "function_id": "0x1::coin::transfer",
    "type_args": ["0x1::aptos_coin::AptosCoin"],
    "args": ["0x123", 1000]
  },
  {
    "function_id": "0x1::coin::transfer", 
    "type_args": ["0x1::aptos_coin::AptosCoin"],
    "args": ["0x456", 2000]
  }
]
```

## Test plan
- [x] Build passes
- [ ] Test with single payload JSON file
- [ ] Test with single payload YAML file
- [ ] Test with batch payload JSON file
- [ ] Test with batch payload YAML file
- [ ] Test batch with --yes flag
- [ ] Test batch failure handling (stop on first error)
- [ ] Test invalid payload error messages

🤖 Generated with [Claude Code](https://claude.ai/code)