### PR TITLE
refactor: standardize Aptos initialization with helper function

### DIFF
--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -1,6 +1,4 @@
 import {
-  Aptos,
-  AptosConfig,
   MoveFunctionId,
   WriteSetChange,
   WriteSetChangeWriteResource,
@@ -19,7 +17,7 @@ import {
 import { proposeEntryFunction } from '../transactions.js';
 import { validateAddress, validateAddresses, validateUInt } from '../validators.js';
 import { loadProfile, signAndSubmitTransaction } from '../signing.js';
-import { getFullnodeUrl } from '../utils.js';
+import { initAptos } from '../utils.js';
 
 export const registerAccountCommand = (program: Command) => {
   const account = program.command('account').description('Multisig account operations');
@@ -55,7 +53,7 @@ export const registerAccountCommand = (program: Command) => {
           const profile = await ensureProfileExists(options.profile);
           const network = await ensureNetworkExists(options.network);
           const { signer, fullnode } = await loadProfile(profile, network);
-          const aptos = new Aptos(new AptosConfig({ fullnode }));
+          const aptos = initAptos(network, fullnode);
           const preparedTxn = await aptos.transaction.build.simple({
             sender: signer.accountAddress,
             data: entryFunction,
@@ -126,7 +124,7 @@ export const registerAccountCommand = (program: Command) => {
           const profile = await ensureProfileExists(options.profile);
           const network = await ensureNetworkExists(options.network);
           const { signer, fullnode } = await loadProfile(profile, network);
-          const aptos = new Aptos(new AptosConfig({ fullnode }));
+          const aptos = initAptos(network, fullnode);
 
           await proposeEntryFunction(aptos, signer, entryFunction, multisig, network);
         } catch (error) {
@@ -151,11 +149,7 @@ export const registerAccountCommand = (program: Command) => {
     .action(
       async (options: { fullnode?: string; multisigAddress?: string; network?: NetworkChoice }) => {
         const network = await ensureNetworkExists(options.network);
-        const aptos = new Aptos(
-          new AptosConfig({
-            fullnode: options.fullnode || getFullnodeUrl(network),
-          })
-        );
+        const aptos = initAptos(network, options.fullnode);
 
         try {
           // owners

--- a/src/commands/decode.ts
+++ b/src/commands/decode.ts
@@ -1,10 +1,9 @@
 import { Command, Option } from 'commander';
-import { Aptos, AptosConfig } from '@aptos-labs/ts-sdk';
 import chalk from 'chalk';
 import { decode } from '@thalalabs/multisig-utils';
 import { ensureNetworkExists } from '../storage.js';
 import { NETWORK_CHOICES, NetworkChoice } from '../constants.js';
-import { getFullnodeUrl } from '../utils.js';
+import { initAptos } from '../utils.js';
 
 export function registerDecodeCommand(program: Command) {
   program
@@ -31,11 +30,7 @@ export function registerDecodeCommand(program: Command) {
     })
     .action(async (options: { bytes: string; network: NetworkChoice; fullnode: string }) => {
       const network = await ensureNetworkExists(options.network);
-      const aptos = new Aptos(
-        new AptosConfig({
-          fullnode: options.fullnode || getFullnodeUrl(network),
-        })
-      );
+      const aptos = initAptos(network, options.fullnode);
 
       try {
         console.log(chalk.blue(`Decoding multisig payload: ${options.bytes}`));

--- a/src/commands/encode.ts
+++ b/src/commands/encode.ts
@@ -1,10 +1,9 @@
 import { Command, Option } from 'commander';
-import { Aptos, AptosConfig } from '@aptos-labs/ts-sdk';
 import chalk from 'chalk';
 import { encode } from '@thalalabs/multisig-utils';
 import { ensureNetworkExists } from '../storage.js';
 import { NETWORK_CHOICES, NetworkChoice } from '../constants.js';
-import { getFullnodeUrl, resolvePayloadInput } from '../utils.js';
+import { initAptos, resolvePayloadInput } from '../utils.js';
 
 export function registerEncodeCommand(program: Command) {
   program
@@ -37,11 +36,7 @@ Examples:
     })
     .action(async (options: { payload: string; network: NetworkChoice; fullnode: string }) => {
       const network = await ensureNetworkExists(options.network);
-      const aptos = new Aptos(
-        new AptosConfig({
-          fullnode: options.fullnode || getFullnodeUrl(network),
-        })
-      );
+      const aptos = initAptos(network, options.fullnode);
       try {
         console.log(chalk.blue(`Encoding transaction payload...`));
         const jsonContent = await resolvePayloadInput(options.payload);

--- a/src/commands/execute.ts
+++ b/src/commands/execute.ts
@@ -2,10 +2,8 @@ import { Command, Option } from 'commander';
 import {
   AccountAddress,
   Aptos,
-  AptosConfig,
   generateRawTransaction,
   generateTransactionPayload,
-  Network,
   SimpleTransaction,
 } from '@aptos-labs/ts-sdk';
 import { decode } from '@thalalabs/multisig-utils';
@@ -18,7 +16,7 @@ import {
   ensureNetworkExists,
 } from '../storage.js';
 import { NETWORK_CHOICES, NetworkChoice } from '../constants.js';
-import { getExplorerUrl } from '../utils.js';
+import { getExplorerUrl, initAptos } from '../utils.js';
 
 export const registerExecuteCommand = (program: Command) => {
   program
@@ -45,7 +43,7 @@ export async function handleExecuteCommand(
 ) {
   try {
     const { signer, fullnode } = await loadProfile(profile, network);
-    const aptos = new Aptos(new AptosConfig({ fullnode }));
+    const aptos = initAptos(network, fullnode);
 
     const [lastResolvedSn] = await aptos.view<[string]>({
       payload: {

--- a/src/commands/proposal.ts
+++ b/src/commands/proposal.ts
@@ -1,4 +1,4 @@
-import { Aptos, AptosConfig } from '@aptos-labs/ts-sdk';
+import { Aptos } from '@aptos-labs/ts-sdk';
 import chalk from 'chalk';
 import { Command, Option } from 'commander';
 import { select } from '@inquirer/prompts';
@@ -6,7 +6,7 @@ import { fetchPendingTxnsSafely } from '../transactions.js';
 import { validateAddress, validateUInt } from '../validators.js';
 import { decode, summarizeTransactionBalanceChanges } from '@thalalabs/multisig-utils';
 import { NETWORK_CHOICES, NetworkChoice } from '../constants.js';
-import { getFullnodeUrl } from '../utils.js';
+import { initAptos } from '../utils.js';
 import {
   AddressBook,
   ensureMultisigAddressExists,
@@ -69,11 +69,7 @@ export const registerProposalCommand = (program: Command) => {
           ({ fullnode } = await loadProfile(profile, network, false));
         }
 
-        const aptos = new Aptos(
-          new AptosConfig({
-            fullnode: fullnode || getFullnodeUrl(network),
-          })
-        );
+        const aptos = initAptos(network, fullnode);
         const n = options.limit || 20;
         const multisig = await ensureMultisigAddressExists(options.multisigAddress);
 

--- a/src/commands/propose.ts
+++ b/src/commands/propose.ts
@@ -1,7 +1,7 @@
 import { Command, Option } from 'commander';
-import { Aptos, AptosConfig, MoveFunctionId } from '@aptos-labs/ts-sdk';
+import { MoveFunctionId } from '@aptos-labs/ts-sdk';
 import { parseEntryFunctionPayload, isBatchPayload, parseBatchPayload } from '../entryFunction.js';
-import { resolvePayloadInput } from '../utils.js';
+import { resolvePayloadInput, initAptos } from '../utils.js';
 import chalk from 'chalk';
 import { proposeEntryFunction } from '../transactions.js';
 import { validateAddress, validateAsset } from '../validators.js';
@@ -87,7 +87,7 @@ Examples:
           }
           
           const { signer, fullnode } = await loadProfile(profile, network);
-          const aptos = new Aptos(new AptosConfig({ fullnode }));
+          const aptos = initAptos(network, fullnode);
           
           // Process each transaction sequentially
           for (let i = 0; i < payloads.length; i++) {
@@ -115,7 +115,7 @@ Examples:
           const entryFunction = parseEntryFunctionPayload(jsonContent);
 
           const { signer, fullnode } = await loadProfile(profile, network);
-          const aptos = new Aptos(new AptosConfig({ fullnode }));
+          const aptos = initAptos(network, fullnode);
           await proposeEntryFunction(
             aptos,
             signer,
@@ -171,7 +171,7 @@ Examples:
         try {
           const network = await ensureNetworkExists(parentOptions.network);
           const { signer, fullnode } = await loadProfile(profile, network);
-          const aptos = new Aptos(new AptosConfig({ fullnode }));
+          const aptos = initAptos(network, fullnode);
           await proposeEntryFunction(
             aptos,
             signer,

--- a/src/commands/simulate.ts
+++ b/src/commands/simulate.ts
@@ -1,4 +1,4 @@
-import { Aptos, AptosConfig } from '@aptos-labs/ts-sdk';
+import { Aptos } from '@aptos-labs/ts-sdk';
 import chalk from 'chalk';
 import { Command, Option } from 'commander';
 import { ensureMultisigAddressExists, ensureNetworkExists } from '../storage.js';
@@ -6,7 +6,7 @@ import { MultisigTransaction, summarizeTransactionBalanceChanges } from '@thalal
 import { decode } from '@thalalabs/multisig-utils';
 import { validateAddress, validateUInt } from '../validators.js';
 import { NETWORK_CHOICES, NetworkChoice } from '../constants.js';
-import { getFullnodeUrl } from '../utils.js';
+import { initAptos } from '../utils.js';
 
 export const registerSimulateCommand = (program: Command) => {
   program
@@ -35,11 +35,7 @@ export const registerSimulateCommand = (program: Command) => {
       }) => {
         const multisig = await ensureMultisigAddressExists(options.multisigAddress);
         const network = await ensureNetworkExists(options.network);
-        const aptos = new Aptos(
-          new AptosConfig({
-            fullnode: options.fullnode || getFullnodeUrl(network),
-          })
-        );
+        const aptos = initAptos(network, options.fullnode);
 
         await handleSimulateCommand(aptos, multisig, options.sequenceNumber);
       }

--- a/src/commands/vote.ts
+++ b/src/commands/vote.ts
@@ -1,4 +1,3 @@
-import { Aptos, AptosConfig } from '@aptos-labs/ts-sdk';
 import chalk from 'chalk';
 import { Command, Option } from 'commander';
 import { validateAddress, validateUInt, validateBool } from '../validators.js';
@@ -9,7 +8,7 @@ import {
   ensureNetworkExists,
 } from '../storage.js';
 import { NETWORK_CHOICES, NetworkChoice } from '../constants.js';
-import { getExplorerUrl } from '../utils.js';
+import { getExplorerUrl, initAptos } from '../utils.js';
 
 export const registerVoteCommand = (program: Command) => {
   program
@@ -52,7 +51,7 @@ export async function handleVoteCommand(
 ) {
   try {
     const { signer, fullnode } = await loadProfile(profile, network);
-    const aptos = new Aptos(new AptosConfig({ fullnode }));
+    const aptos = initAptos(network, fullnode);
 
     const txn = await aptos.transaction.build.simple({
       sender: signer.accountAddress,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { Aptos, AptosConfig } from '@aptos-labs/ts-sdk';
 import { NetworkChoice } from './constants.js';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -20,6 +21,14 @@ export function getFullnodeUrl(network: NetworkChoice): string {
     default:
       throw new Error(`Unknown network: ${network}`);
   }
+}
+
+export function initAptos(network: NetworkChoice, fullnode?: string): Aptos {
+  return new Aptos(
+    new AptosConfig({
+      fullnode: fullnode || getFullnodeUrl(network),
+    })
+  );
 }
 
 export function getConfigPath(network: NetworkChoice): string {


### PR DESCRIPTION
## Summary
- Created `initAptos` helper function in `utils.ts` to standardize Aptos client initialization
- Replaced all direct `new Aptos(new AptosConfig(...))` instantiations with the helper function
- Updated 8 command files and removed redundant imports

## Changes
- **Added**: `initAptos(network: NetworkChoice, fullnode?: string)` helper in utils.ts
- **Updated**: All command files to use the new helper:
  - propose.ts (3 instances)
  - vote.ts (1 instance) 
  - execute.ts (1 instance)
  - account.ts (3 instances)
  - simulate.ts (1 instance)
  - proposal.ts (1 instance)
  - decode.ts (1 instance)
  - encode.ts (1 instance)

## Benefits
- ✅ Consistent initialization pattern across the codebase
- ✅ Follows DRY (Don't Repeat Yourself) principle
- ✅ Easier to maintain and update initialization logic in one place
- ✅ Cleaner imports in command files

## Test plan
- [ ] Verify all commands still work correctly
- [ ] Test with custom fullnode URLs
- [ ] Test with all supported networks

🤖 Generated with [Claude Code](https://claude.ai/code)