### PR TITLE
refactor: replace --ignore-simulate flag with --no-simulate

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -68,7 +68,7 @@ Options:
                                     "movement-mainnet", "movement-testnet",
                                     "custom")
   -p, --profile <string>            Profile to use for the transaction
-  --ignore-simulate <boolean>       ignore tx simulation (default: false)
+  --no-simulate                      skip tx simulation
   -h, --help                        display help for command
 Commands:
   raw [options]                     Propose a raw transaction from a payload

--- a/src/commands/propose.ts
+++ b/src/commands/propose.ts
@@ -21,7 +21,7 @@ export const registerProposeCommand = (program: Command) => {
     .option('-m, --multisig-address <address>', 'multisig account address', validateAddress)
     .addOption(new Option('--network <network>', 'network to use').choices(NETWORK_CHOICES))
     .option('-p, --profile <string>', 'Profile to use for the transaction')
-    .option('--ignore-simulate <boolean>', 'ignore tx simulation', false);
+    .option('--no-simulate', 'skip tx simulation');
 
   // Raw transaction from file
   propose
@@ -100,7 +100,7 @@ Examples:
                 payloads[i],
                 multisig,
                 network,
-                !parentOptions.ignoreSimulate
+                parentOptions.simulate
               );
             } catch (error) {
               console.error(chalk.red(`\nTransaction ${i + 1}/${payloads.length} failed: ${(error as Error).message}`));
@@ -122,7 +122,7 @@ Examples:
             entryFunction,
             multisig,
             network,
-            !parentOptions.ignoreSimulate
+            parentOptions.simulate
           );
         }
       } catch (error) {
@@ -178,7 +178,7 @@ Examples:
             entryFunction,
             multisig,
             network,
-            !parentOptions.ignoreSimulate
+            parentOptions.simulate
           );
         } catch (error) {
           console.error(chalk.red(`Error: ${(error as Error).message}`));


### PR DESCRIPTION
## Summary
- Replaced `--ignore-simulate <boolean>` with standard boolean flag `--no-simulate`
- Provides more intuitive CLI experience - just use `--no-simulate` to skip simulation
- Simulation remains enabled by default (safer option)

## Changes
- Updated flag definition from `.option('--ignore-simulate <boolean>', ...)` to `.option('--no-simulate', ...)`
- Changed code from `!parentOptions.ignoreSimulate` to `parentOptions.simulate`
- Updated documentation to reflect new flag usage

## Test plan
- [ ] Build passes with `pnpm build`
- [ ] Test `safely propose` commands work without the flag (simulation enabled)
- [ ] Test `safely propose --no-simulate` skips simulation

🤖 Generated with [Claude Code](https://claude.ai/code)