### PR TITLE
fix: infer network from profile when no --network option provided

### DIFF
--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -52,7 +52,7 @@ export const registerAccountCommand = (program: Command) => {
         };
         try {
           const profile = await ensureProfileExists(options.profile);
-          const network = await ensureNetworkExists(options.network);
+          const network = await ensureNetworkExists(options.network, options.profile);
           const { signer, fullnode } = await loadProfile(profile, network);
           const aptos = initAptos(network, fullnode);
           const preparedTxn = await aptos.transaction.build.simple({
@@ -123,7 +123,7 @@ export const registerAccountCommand = (program: Command) => {
         try {
           const multisig = await ensureMultisigAddressExists(options.multisigAddress);
           const profile = await ensureProfileExists(options.profile);
-          const network = await ensureNetworkExists(options.network);
+          const network = await ensureNetworkExists(options.network, options.profile);
           const { signer, fullnode } = await loadProfile(profile, network);
           const aptos = initAptos(network, fullnode);
 

--- a/src/commands/execute.ts
+++ b/src/commands/execute.ts
@@ -28,7 +28,7 @@ export const registerExecuteCommand = (program: Command) => {
     .action(
       async (options: { multisigAddress?: string; network?: NetworkChoice; profile?: string }) => {
         try {
-          const network = await ensureNetworkExists(options.network);
+          const network = await ensureNetworkExists(options.network, options.profile);
           const hash = await handleExecuteCommand(
             await ensureMultisigAddressExists(options.multisigAddress),
             await ensureProfileExists(options.profile),

--- a/src/commands/proposal.ts
+++ b/src/commands/proposal.ts
@@ -59,7 +59,7 @@ export const registerProposalCommand = (program: Command) => {
         sequenceNumber?: number;
         limit?: number;
       }) => {
-        const network = await ensureNetworkExists(options.network);
+        const network = await ensureNetworkExists(options.network, options.profile);
         const profile = await ensureProfileExists(options.profile);
         let fullnode = options.fullnode;
 

--- a/src/commands/propose.ts
+++ b/src/commands/propose.ts
@@ -64,7 +64,7 @@ Examples:
       const parentOptions = cmd.parent.opts();
       const multisig = await ensureMultisigAddressExists(parentOptions.multisigAddress);
       const profile = await ensureProfileExists(parentOptions.profile);
-      const network = await ensureNetworkExists(parentOptions.network);
+      const network = await ensureNetworkExists(parentOptions.network, parentOptions.profile);
 
       try {
         const jsonContent = await resolvePayloadInput(options.payload);
@@ -173,7 +173,7 @@ Examples:
                 functionArguments: [options.asset.address, options.recipient, options.amount],
               };
         try {
-          const network = await ensureNetworkExists(parentOptions.network);
+          const network = await ensureNetworkExists(parentOptions.network, parentOptions.profile);
           const { signer, fullnode } = await loadProfile(profile, network);
           const aptos = initAptos(network, fullnode);
           await proposeEntryFunction(

--- a/src/commands/vote.ts
+++ b/src/commands/vote.ts
@@ -32,7 +32,7 @@ export const registerVoteCommand = (program: Command) => {
         profile?: string;
       }) => {
         try {
-          const network = await ensureNetworkExists(options.network);
+          const network = await ensureNetworkExists(options.network, options.profile);
           const hash = await handleVoteCommand(
             options.sequenceNumber,
             options.approve,


### PR DESCRIPTION
Previously when no --network option was provided, the CLI would default to 'aptos-mainnet' causing explorer URLs to show network=mainnet even when using devnet profiles. This fix adds network inference from profile configuration so that devnet profiles correctly show network=devnet in explorer URLs.

🤖 Generated with [Claude Code](https://claude.ai/code)