### PR TITLE
Improve proposal view header layout

### DIFF
--- a/src/ui/ProposalView.tsx
+++ b/src/ui/ProposalView.tsx
@@ -282,10 +282,13 @@ const ProposalView: React.FC<ProposalViewProps> = ({
   return (
     <Box flexDirection="column" gap={1}>
       {/* Header */}
-      <Box borderStyle="round" paddingX={1}>
-        <Text bold>
-          {multisigAddress.slice(0, 6)}...{multisigAddress.slice(-4)} | {network} | {proposals.length} pending proposals | Last refreshed: {lastRefreshed.toLocaleTimeString()}
-        </Text>
+      <Box borderStyle="single" paddingX={1}>
+        <Box flexDirection="column">
+          <Text bold>{'Multisig: '.padEnd(10)}{multisigAddress.slice(0, 6)}...{multisigAddress.slice(-4)}</Text>
+          <Text bold>{'Network:'.padEnd(10)}{network}</Text>
+          <Text bold>{'#Pending:'.padEnd(10)}{proposals.length}</Text>
+          <Text bold>{'Updated:'.padEnd(10)}{lastRefreshed.toLocaleTimeString('en-US')}</Text>
+        </Box>
       </Box>
 
       {/* Table */}


### PR DESCRIPTION
## Summary
- Changed proposal view header from single-line to multi-line display
- Added field labels with consistent padding for better alignment
- Forced English locale for time display to ensure consistency

## Test plan
- [x] Tested the new header layout in proposal view
- [x] Verified field alignment with padded labels
- [x] Confirmed time displays in English format

🤖 Generated with [Claude Code](https://claude.ai/code)