### PR TITLE
Handle multisig transaction execution failures in UI

### DIFF
--- a/src/ui/ProposalView.tsx
+++ b/src/ui/ProposalView.tsx
@@ -283,8 +283,12 @@ const ProposalView: React.FC<ProposalViewProps> = ({
       const actionPast = reject ? 'Reject' : 'Execute';
       setConfirmAction(null); // Clear confirmation immediately
       setActionMessage(chalk.yellow(`⏳ ${action} transaction... Please wait while the transaction is submitted to the blockchain.`));
-      const hash = await handleExecuteCommand(multisigAddress, profile, network as NetworkChoice, reject, true);
-      setActionMessage(chalk.green(`✅ ${actionPast} successful: ${getExplorerUrl(network as NetworkChoice, `txn/${hash}`)}`));
+      const result = await handleExecuteCommand(multisigAddress, profile, network as NetworkChoice, reject, true);
+      if (reject || result.success) {
+        setActionMessage(chalk.green(`✅ ${actionPast} successful: ${getExplorerUrl(network as NetworkChoice, `txn/${result.hash}`)}`));
+      } else {
+        setActionMessage(chalk.yellow(`⚠️ ${actionPast} committed but failed: ${getExplorerUrl(network as NetworkChoice, `txn/${result.hash}`)}`));
+      }
       await fetchProposals();
     } catch (error) {
       setActionMessage(chalk.red(`❌ ${reject ? 'Reject' : 'Execute'} failed: ${(error as Error).message}`));


### PR DESCRIPTION
## Summary
- Update `handleExecuteCommand` to return both hash and success status
- Display "Execute committed but failed" when execution succeeds on-chain but underlying transaction fails
- Keep existing "Execute ok" message for successful executions and all reject operations

## Test plan
- [ ] Test executing a multisig transaction that succeeds
- [ ] Test executing a multisig transaction that fails (e.g., insufficient funds)
- [ ] Test rejecting a multisig transaction
- [ ] Verify messages display correctly in both CLI and interactive UI

🤖 Generated with [Claude Code](https://claude.ai/code)