### PR TITLE
Fix: Display vector<u8> as hex strings in proposal view

### DIFF
--- a/src/ui/ProposalView.tsx
+++ b/src/ui/ProposalView.tsx
@@ -10,7 +10,8 @@ import {
 import {
   getBalanceChangesData,
   BalanceChange,
-  isWriteSetChangeWriteResource
+  isWriteSetChangeWriteResource,
+  safeStringify
 } from '../utils.js';
 import { InputEntryFunctionData } from '@aptos-labs/ts-sdk';
 import { initAptos, getExplorerUrl } from '../utils.js';
@@ -58,15 +59,6 @@ function formatFunctionId(functionId: string): string {
   return functionId;
 }
 
-// Helper to safely stringify objects with BigInt
-function safeStringify(obj: unknown, indent: number = 2): string {
-  return JSON.stringify(obj, (_key, value) => {
-    if (typeof value === 'bigint') {
-      return value.toString();
-    }
-    return value;
-  }, indent);
-}
 
 interface ProposalViewProps {
   multisigAddress: string;


### PR DESCRIPTION
## Summary
- Fixed the display of `vector<u8>` parameters in proposal view to show as compact hex strings instead of verbose object arrays
- Added a `safeStringify` utility function that properly handles vector<u8> conversion
- Improves readability for transactions like `publish_package_txn`

## Problem
When viewing proposals containing functions with `vector<u8>` parameters (like `publish_package_txn`), the data was displayed as arrays of objects:
```json
[
  {"value": 11},
  {"value": 84},
  {"value": 101},
  ...
]
```

## Solution
Now displays as compact hex strings:
```json
"0x0b5465..."
```

## Changes
1. Added `safeStringify` utility function to `utils.ts` that:
   - Handles BigInt to string conversion
   - Converts `vector<u8>` arrays to hex strings
   - Converts `vector<vector<u8>>` to arrays of hex strings

2. Updated `ProposalView.tsx` to use the shared utility function

## Test plan
- [x] Build passes
- [x] Tested conversion logic with sample data
- [x] Verified hex output is correct

🤖 Generated with [Claude Code](https://claude.ai/code)