### PR TITLE
Fix: Ledger hanging issue in proposal command

### DIFF
--- a/src/ledger/ledger.ts
+++ b/src/ledger/ledger.ts
@@ -6,6 +6,10 @@ import AptosLedgerClient, { publicKeyToAddress } from './AptosLedgerClient.js';
 import LedgerSigner from './LedgerSigner.js';
 import { AccountAddress } from '@aptos-labs/ts-sdk';
 
+// Singleton storage for active Ledger connections
+let activeSigner: LedgerSigner | null = null;
+let activeLedgerIndex: number | null = null;
+
 // Initializes a LedgerClient connection with a Ledger hardware wallet.
 // This connection must be terminated with `closeLedgerClient` when it is no longer needed.
 export async function initLedgerClient(): Promise<AptosLedgerClient> {
@@ -21,6 +25,18 @@ export async function initLedgerClient(): Promise<AptosLedgerClient> {
 
 // Initializes a LedgerSigner object from a specific key (denoted by key index) on a Ledger hardware wallet.
 export async function initLedgerSigner(ledgerIndex: number): Promise<LedgerSigner> {
+  // If we already have an active signer for the same ledger index, return it
+  if (activeSigner && activeLedgerIndex === ledgerIndex) {
+    return activeSigner;
+  }
+
+  // If we have a signer for a different index, close it first
+  if (activeSigner) {
+    await activeSigner.close();
+    activeSigner = null;
+    activeLedgerIndex = null;
+  }
+
   const ledgerClient = await initLedgerClient();
   const hdPath = getHDPath(ledgerIndex); // Example HD path for Aptos
   const publicKeyResponse = await ledgerClient.getAccount(hdPath);
@@ -31,6 +47,10 @@ export async function initLedgerSigner(ledgerIndex: number): Promise<LedgerSigne
     publicKeyResponse.publicKey.toString('hex'),
     AccountAddress.fromString(publicKeyResponse.address)
   );
+
+  // Store the active signer and index
+  activeSigner = signer;
+  activeLedgerIndex = ledgerIndex;
 
   return signer;
 }
@@ -56,4 +76,10 @@ export function getLedgerIndex(hdPath: string): number {
 // Note: Any time `initLedgerClient` is called, this method must be called to close the connection.
 export async function closeLedger(signer: LedgerSigner) {
   await signer.close();
+
+  // Clear singleton state if this was the active signer
+  if (activeSigner === signer) {
+    activeSigner = null;
+    activeLedgerIndex = null;
+  }
 }


### PR DESCRIPTION
## Summary
- Fixes the hanging issue when running `safely proposal` with a Ledger profile
- Implements singleton pattern for Ledger connections to prevent duplicate Transport connections

## Problem
When running `safely proposal` with a Ledger profile, the command would hang indefinitely because `initLedgerSigner` was being called twice:
1. First in `proposal.ts` when loading the profile  
2. Second in `ProposalView.tsx` during component initialization

This created duplicate Transport connections to the Ledger device, but Ledger hardware only supports one active connection at a time, causing the second connection attempt to hang.

## Solution
Implemented a singleton pattern in `src/ledger/ledger.ts` that:
- Maintains a single active Ledger connection at module level
- Returns the existing signer instance when requesting the same ledger index
- Properly closes the previous connection when switching to a different index
- Clears singleton state when a signer is explicitly closed

## Test Plan
- [x] Build succeeds without TypeScript errors
- [ ] Test `safely proposal` with Ledger profile - should no longer hang
- [ ] Verify voting and executing still work with Ledger
- [ ] Confirm switching between different Ledger indices works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)