### PR TITLE
Remove default parameter values from functions

### DIFF
--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -53,7 +53,7 @@ export const registerAccountCommand = (program: Command) => {
         try {
           const profile = await ensureProfileExists(options.profile);
           const network = await ensureNetworkExists(options.network, options.profile);
-          const { signer, fullnode } = await loadProfile(profile, network);
+          const { signer, fullnode } = await loadProfile(profile, network, true);
           const aptos = initAptos(network, fullnode);
           const preparedTxn = await aptos.transaction.build.simple({
             sender: signer.accountAddress,
@@ -124,10 +124,10 @@ export const registerAccountCommand = (program: Command) => {
           const multisig = await ensureMultisigAddressExists(options.multisigAddress);
           const profile = await ensureProfileExists(options.profile);
           const network = await ensureNetworkExists(options.network, options.profile);
-          const { signer, fullnode } = await loadProfile(profile, network);
+          const { signer, fullnode } = await loadProfile(profile, network, true);
           const aptos = initAptos(network, fullnode);
 
-          await proposeEntryFunction(aptos, signer, entryFunction, multisig, network);
+          await proposeEntryFunction(aptos, signer, entryFunction, multisig, network, true);
         } catch (error) {
           console.error(chalk.red(`Error: ${(error as Error).message}`));
         }

--- a/src/commands/execute.ts
+++ b/src/commands/execute.ts
@@ -73,7 +73,7 @@ export async function handleExecuteCommand(
   skipConfirmation: boolean
 ): Promise<{ hash: string; success: boolean }> {
   try {
-    const { signer, fullnode } = await loadProfile(profile, network);
+    const { signer, fullnode } = await loadProfile(profile, network, true);
     const aptos = initAptos(network, fullnode);
 
     const [lastResolvedSn] = await aptos.view<[string]>({

--- a/src/commands/propose.ts
+++ b/src/commands/propose.ts
@@ -86,7 +86,7 @@ Examples:
             }
           }
 
-          const { signer, fullnode } = await loadProfile(profile, network);
+          const { signer, fullnode } = await loadProfile(profile, network, true);
           const aptos = initAptos(network, fullnode);
 
           // Process each transaction sequentially
@@ -118,7 +118,7 @@ Examples:
           // Single payload - use existing logic
           const entryFunction = parseEntryFunctionPayload(jsonContent);
 
-          const { signer, fullnode } = await loadProfile(profile, network);
+          const { signer, fullnode } = await loadProfile(profile, network, true);
           const aptos = initAptos(network, fullnode);
           await proposeEntryFunction(
             aptos,
@@ -174,7 +174,7 @@ Examples:
               };
         try {
           const network = await ensureNetworkExists(parentOptions.network, parentOptions.profile);
-          const { signer, fullnode } = await loadProfile(profile, network);
+          const { signer, fullnode } = await loadProfile(profile, network, true);
           const aptos = initAptos(network, fullnode);
           await proposeEntryFunction(
             aptos,

--- a/src/commands/vote.ts
+++ b/src/commands/vote.ts
@@ -56,7 +56,7 @@ export async function handleVoteCommand(
   profile: string
 ): Promise<string> {
   try {
-    const { signer, fullnode } = await loadProfile(profile, network);
+    const { signer, fullnode } = await loadProfile(profile, network, true);
     const aptos = initAptos(network, fullnode);
 
     const txn = await aptos.transaction.build.simple({

--- a/src/ledger/AptosLedgerClient.ts
+++ b/src/ledger/AptosLedgerClient.ts
@@ -89,8 +89,7 @@ export default class AptosLedgerClient {
   async getAccount(
     path: string,
     // the type annotation is needed for doc generator
-    // eslint-disable-next-line @typescript-eslint/no-inferrable-types
-    display: boolean = false
+    display: boolean
   ): Promise<AddressData> {
     return this.getAccountRaw(path, display);
   }
@@ -98,8 +97,7 @@ export default class AptosLedgerClient {
   async getAccountRaw(
     path: string,
     // the type annotation is needed for doc generator
-    // eslint-disable-next-line @typescript-eslint/no-inferrable-types
-    display: boolean = false
+    display: boolean
   ): Promise<AddressData> {
     const pathBuffer = serializeBip32(path);
     const responseBuffer = await this.sendToDevice(

--- a/src/ledger/ledger.ts
+++ b/src/ledger/ledger.ts
@@ -23,7 +23,7 @@ export async function initLedgerClient(): Promise<AptosLedgerClient> {
 export async function initLedgerSigner(ledgerIndex: number): Promise<LedgerSigner> {
   const ledgerClient = await initLedgerClient();
   const hdPath = getHDPath(ledgerIndex); // Example HD path for Aptos
-  const publicKeyResponse = await ledgerClient.getAccount(hdPath);
+  const publicKeyResponse = await ledgerClient.getAccount(hdPath, false);
 
   const signer = new LedgerSigner(
     ledgerClient,

--- a/src/signing.ts
+++ b/src/signing.ts
@@ -26,7 +26,7 @@ type ProfileData = {
 export async function loadProfile(
   profile: string,
   network: NetworkChoice,
-  includeSigner = true
+  includeSigner: boolean
 ): Promise<Profile> {
   // Load from the network-specific config path
   const configPath = getConfigPath(network);

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -20,7 +20,7 @@ export async function proposeEntryFunction(
   entryFunction: InputEntryFunctionData,
   multisigAddress: string,
   network: NetworkChoice,
-  simulate = true
+  simulate: boolean
 ) {
   // Fetch ABI
   let entryFunctionABI = await fetchEntryFunctionAbi(

--- a/src/ui/ProposalView.tsx
+++ b/src/ui/ProposalView.tsx
@@ -269,7 +269,7 @@ const ProposalView: React.FC<ProposalViewProps> = ({
   };
 
   // Handle execute with confirmation
-  const handleExecute = async (reject: boolean = false) => {
+  const handleExecute = async (reject: boolean) => {
     try {
       const action = reject ? 'Rejecting' : 'Executing';
       const actionPast = reject ? 'Reject' : 'Execute';
@@ -483,7 +483,7 @@ const ProposalExpandedContent: React.FC<ProposalExpandedContentProps> = ({
 }) => {
   // Memoize heavy computations
   const payloadString = useMemo(() =>
-    proposal.payload ? safeStringify(proposal.payload) : null,
+    proposal.payload ? safeStringify(proposal.payload, 2) : null,
     [proposal.payload]
   );
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -241,7 +241,7 @@ export async function getBalanceChangesData(
  * - Converts vector<u8> (array of U8 objects) to hex string
  * - Converts vector<vector<u8>> to array of hex strings
  */
-export function safeStringify(obj: unknown, indent: number = 2): string {
+export function safeStringify(obj: unknown, indent: number): string {
   return JSON.stringify(
     obj,
     (_key, value) => {


### PR DESCRIPTION
## Summary
- remove default parameter defaults from helpers like `proposeEntryFunction`, `loadProfile`, and `safeStringify`
- update CLI commands and UI flows to pass explicit simulation and signer flags
- require ledger account retrieval to receive an explicit display flag

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d3bf6ac11c8332b0c13d6fe376fcc2