### PR TITLE
Fix expanded proposal vote icons

### DIFF
--- a/src/ui/ProposalView.tsx
+++ b/src/ui/ProposalView.tsx
@@ -520,12 +520,12 @@ const ProposalExpandedContent: React.FC<ProposalExpandedContentProps> = ({
           <Text bold>Votes</Text>
           {proposal.yesVotes.map((voter, i) => (
             <Text key={`yes-${i}`} color="green">
-              {'  '}Y <AddressLink address={voter} network={network} />
+              {'  '}● <AddressLink address={voter} network={network} />
             </Text>
           ))}
           {proposal.noVotes.map((voter, i) => (
             <Text key={`no-${i}`} color="red">
-              {'  '}N <AddressLink address={voter} network={network} />
+              {'  '}✗ <AddressLink address={voter} network={network} />
             </Text>
           ))}
           {proposal.yesVotes.length === 0 && proposal.noVotes.length === 0 && (


### PR DESCRIPTION
## Summary
- replace the expanded proposal vote labels with the same icons used in the proposal row display so the vote UI is consistent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d893836cb083328e5f84cfd1d3a443