### PR TITLE
Add known address labels to AddressLink

### DIFF
--- a/src/labels.ts
+++ b/src/labels.ts
@@ -1,3 +1,5 @@
+import { AccountAddress } from '@aptos-labs/ts-sdk';
+
 // Copied from https://github.com/aptos-labs/explorer/blob/main/src/constants.tsx
 export const knownAddresses: Record<string, string> = {
   '0x1': 'Framework (0x1)',
@@ -107,3 +109,21 @@ export const knownAddresses: Record<string, string> = {
   '0x4b947ed016c64bde81972d69ea7d356de670d57fd2608b129f4d94ac0d0ee61': 'Emojicoin.fun Registry',
   '0xface729284ae5729100b3a9ad7f7cc025ea09739cd6e7252aff0beb53619cafe': 'Emojicoin.fun',
 };
+
+const normalizedKnownAddresses: Record<string, string> = Object.fromEntries(
+  Object.entries(knownAddresses).map(([address, label]) => [AccountAddress.from(address).toString(), label])
+);
+
+export function getAddressLabel(address: string): string | undefined {
+  if (!address) {
+    return undefined;
+  }
+
+  try {
+    const normalizedAddress = AccountAddress.from(address).toString();
+
+    return normalizedKnownAddresses[normalizedAddress];
+  } catch {
+    return undefined;
+  }
+}

--- a/src/ui/ProposalView.tsx
+++ b/src/ui/ProposalView.tsx
@@ -20,6 +20,7 @@ import { handleExecuteCommand } from '../commands/execute.js';
 import { handleVoteCommand } from '../commands/vote.js';
 import { loadProfile } from '../signing.js';
 import { analyzeModuleChanges, ModuleChangesByAddress } from '../moduleAnalyzer.js';
+import { getAddressLabel } from '../labels.js';
 
 // Helper function to truncate address uniformly
 function truncateAddress(address: string): string {
@@ -39,10 +40,12 @@ interface AddressLinkProps {
 const AddressLink: React.FC<AddressLinkProps> = React.memo(({ address, network, color }) => {
   const url = getExplorerUrl(network as NetworkChoice, `account/${address}`);
   const displayAddr = truncateAddress(address);
+  const label = getAddressLabel(address);
+  const displayText = label ? `${label} (${displayAddr})` : displayAddr;
 
   return (
     <Link url={url}>
-      {color ? <Text color={color}>{displayAddr}</Text> : displayAddr}
+      <Text color={color}>{displayText}</Text>
     </Link>
   );
 });


### PR DESCRIPTION
## Summary
- add a normalized lookup for known address labels using `AccountAddress.from(...).toString()` for canonicalization
- display known labels alongside addresses in the AddressLink component
- simplify `getAddressLabel` to accept string parameters only

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d893670bf48332beb4d6ad093c8286