### PR TITLE
Filter out unchanged balances in balance changes display

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -219,13 +219,16 @@ export async function getBalanceChangesData(
       const balanceAfter = balanceAfterRaw / 10 ** decimals;
       const balanceBefore = balanceBeforeRaw / 10 ** decimals;
 
-      balanceChanges.push({
-        address: accountAddress,
-        asset: faType,
-        symbol,
-        balanceBefore,
-        balanceAfter,
-      });
+      // Only include if balance actually changes
+      if (balanceBefore !== balanceAfter) {
+        balanceChanges.push({
+          address: accountAddress,
+          asset: faType,
+          symbol,
+          balanceBefore,
+          balanceAfter,
+        });
+      }
     } catch (error) {
       continue;
     }


### PR DESCRIPTION
## Summary
- Filter balance changes to only show when balances actually change
- Prevents displaying redundant zero-change entries in both TUI and simulate command

## Changes
- Updated `getBalanceChangesData()` in `src/utils.ts` to filter out balance changes where `balanceBefore === balanceAfter`
- Affects both ProposalView TUI and simulate command output

## Test plan
- [ ] Test simulate command with transactions that have zero balance changes
- [ ] Test TUI proposal view with transactions that have zero balance changes
- [ ] Verify actual balance changes still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)