### PR TITLE
Migrate config to ~/.safely and refactor storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,9 +32,6 @@ build/
 # Address book DB
 addressbook.json
 
-# Safely storage file
-safelyStorage.json
-
 # Test JSON files
 *.json
 !package.json

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "ink-link": "^5.0.0",
     "ink-spinner": "^5.0.0",
     "ink-text-input": "^6.0.0",
-    "lowdb": "^7.0.1",
     "react": "^19.1.1",
     "yaml": "^2.6.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       ink-text-input:
         specifier: ^6.0.0
         version: 6.0.0(ink@6.3.1(@types/react@19.1.13)(react@19.1.1))(react@19.1.1)
-      lowdb:
-        specifier: ^7.0.1
-        version: 7.0.1
       react:
         specifier: ^19.1.1
         version: 19.1.1
@@ -897,10 +894,6 @@ packages:
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
-  lowdb@7.0.1:
-    resolution: {integrity: sha512-neJAj8GwF0e8EpycYIDFqEPcx9Qz4GUho20jWFR7YiFeXzF1YMLdxB36PypcTSPMA+4+LvgyMacYhlr18Zlymw==}
-    engines: {node: '>=18'}
-
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
@@ -1180,10 +1173,6 @@ packages:
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
-
-  steno@4.0.2:
-    resolution: {integrity: sha512-yhPIQXjrlt1xv7dyPQg2P17URmXbuM5pdGkpiMB3RenprfiBlvK415Lctfe0eshk90oA7/tNq7WEiMK8RSP39A==}
-    engines: {node: '>=18'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2247,10 +2236,6 @@ snapshots:
 
   lodash@4.17.21: {}
 
-  lowdb@7.0.1:
-    dependencies:
-      steno: 4.0.2
-
   lowercase-keys@2.0.0: {}
 
   make-error@1.3.6: {}
@@ -2482,8 +2467,6 @@ snapshots:
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
-
-  steno@4.0.2: {}
 
   string-width@4.2.3:
     dependencies:

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -124,6 +124,11 @@ export function getProfileByName(name: string): ProfileInfo | null {
   return profiles.find((p) => p.name === name) || null;
 }
 
+export function getProfileNetwork(profileName: string): NetworkChoice | null {
+  const profile = getProfileByName(profileName);
+  return profile?.network ?? null;
+}
+
 function readProfileConfig(profile: string, network: NetworkChoice): ConfigProfile {
   const configPath = getConfigPath(network);
 


### PR DESCRIPTION
## Summary
- Migrate config from `./safelyStorage.json` to `~/.safely/config.json` for user-global settings
- Replace lowdb with native Node.js fs operations (zero dependencies)
- Refactor duplicate code with generic factory functions
- Eliminate code duplication in network inference logic

## Changes

### Config Storage Migration
- Move config from current directory to `~/.safely/config.json`
- Remove lowdb dependency (simpler, more maintainable)
- Implement atomic writes using temp file + rename for corruption safety
- Auto-create `~/.safely/` directory on first use

### Code Deduplication
- Add `createDefaultAccessor()` factory for multisig/network/profile defaults
- Add `createEnsure()` factory for ensure functions
- Add `getProfileNetwork()` in profiles.ts for single source of truth
- Simplify `ensureNetworkExists()` to use profiles.ts logic
- Remove ~40 lines of duplicate network mapping code

### Cleanup
- Rename internal functions: `readDb` → `readStorage`, `writeDb` → `updateStorage`
- Remove yaml import from storage.ts (no longer parses config files)
- Clean up .gitignore (remove safelyStorage.json entry)
- Add numbered comments to clarify fallback chain in `ensureNetworkExists()`

## Impact
- **5 files changed, 125 insertions(+), 180 deletions(-55 net lines)**
- Config now user-global instead of per-directory
- Better separation of concerns (storage.ts doesn't parse YAML)
- More maintainable and testable code
- Zero dependencies for config storage

## Test plan
- [ ] Test config is created at `~/.safely/config.json` on first use
- [ ] Test default multisig/network/profile storage and retrieval
- [ ] Test address book add/remove operations
- [ ] Test network inference from profiles works correctly
- [ ] Test all commands still work with new storage location

🤖 Generated with [Claude Code](https://claude.com/claude-code)