### PR TITLE
Refactor CLI API to network-first design with validation

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -176,7 +176,6 @@ Options:
   --fullnode <url>                  Fullnode URL for custom network
   -s, --sequence-number <number>    fetch transaction with specific sequence
                                     number
-  -p, --profile <string>            Profile to use for the transaction
   -h, --help                        display help for command
 ```
 

--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -13,7 +13,7 @@ import {
 import { proposeEntryFunction } from '../transactions.js';
 import { validateAddress, validateAddresses, validateUInt } from '../validators.js';
 import { signAndSubmitTransaction } from '../signing.js';
-import { loadProfile } from '../profiles.js';
+import { loadProfile, validateProfileNetwork } from '../profiles.js';
 import { initAptos } from '../utils.js';
 
 export const registerAccountCommand = (program: Command) => {
@@ -52,8 +52,9 @@ export const registerAccountCommand = (program: Command) => {
           ],
         };
         try {
+          const network = await ensureNetworkExists(options.network);
           const profile = await ensureProfileExists(options.profile);
-          const network = await ensureNetworkExists(options.network, options.profile);
+          validateProfileNetwork(profile, network);
           const { signer, fullnode } = await loadProfile(profile, network);
           const aptos = initAptos(network, fullnode);
           const preparedTxn = await aptos.transaction.build.simple({
@@ -123,8 +124,9 @@ export const registerAccountCommand = (program: Command) => {
         };
         try {
           const multisig = await ensureMultisigAddressExists(options.multisigAddress);
+          const network = await ensureNetworkExists(options.network);
           const profile = await ensureProfileExists(options.profile);
-          const network = await ensureNetworkExists(options.network, options.profile);
+          validateProfileNetwork(profile, network);
           const { signer, fullnode } = await loadProfile(profile, network);
           const aptos = initAptos(network, fullnode);
 

--- a/src/commands/execute.ts
+++ b/src/commands/execute.ts
@@ -12,7 +12,7 @@ import chalk from 'chalk';
 import { confirm } from '@inquirer/prompts';
 import { validateAddress } from '../validators.js';
 import { signAndSubmitTransaction } from '../signing.js';
-import { loadProfile } from '../profiles.js';
+import { loadProfile, validateProfileNetwork } from '../profiles.js';
 import {
   ensureMultisigAddressExists,
   ensureProfileExists,
@@ -37,10 +37,12 @@ export const registerExecuteCommand = (program: Command) => {
         reject?: boolean;
       }) => {
         try {
-          const network = await ensureNetworkExists(options.network, options.profile);
+          const network = await ensureNetworkExists(options.network);
+          const profile = await ensureProfileExists(options.profile);
+          validateProfileNetwork(profile, network);
           const result = await handleExecuteCommand(
             await ensureMultisigAddressExists(options.multisigAddress),
-            await ensureProfileExists(options.profile),
+            profile,
             network,
             options.reject ?? false,
             false

--- a/src/commands/proposal.ts
+++ b/src/commands/proposal.ts
@@ -1,12 +1,7 @@
 import { Command, Option } from 'commander';
 import { validateAddress, validateUInt } from '../validators.js';
 import { NETWORK_CHOICES, NetworkChoice } from '../constants.js';
-import {
-  ensureMultisigAddressExists,
-  ensureNetworkExists,
-  ensureProfileExists,
-} from '../storage.js';
-import { getProfileFullnode } from '../profiles.js';
+import { ensureMultisigAddressExists, ensureNetworkExists } from '../storage.js';
 import { initAptos, safeStringify } from '../utils.js';
 import { fetchPendingTxns } from '../transactions.js';
 
@@ -28,27 +23,18 @@ export const registerProposalCommand = (program: Command) => {
       'fetch transaction with specific sequence number',
       validateUInt
     )
-    .option('-p, --profile <string>', 'Profile to use for the transaction')
     .action(
       async (options: {
         multisigAddress: string;
         network?: NetworkChoice;
-        profile?: string;
         fullnode?: string;
         sequenceNumber?: number;
       }) => {
-        const network = await ensureNetworkExists(options.network, options.profile);
-        const profile = await ensureProfileExists(options.profile);
-        let fullnode = options.fullnode;
-
-        if (!fullnode) {
-          fullnode = getProfileFullnode(profile, network);
-        }
-
+        const network = await ensureNetworkExists(options.network);
         const multisig = await ensureMultisigAddressExists(options.multisigAddress);
 
         // Always output JSON for automation/scripting
-        const aptos = initAptos(network, fullnode);
+        const aptos = initAptos(network, options.fullnode);
         const txns = await fetchPendingTxns(aptos, multisig, options.sequenceNumber);
 
         // Format proposals for JSON output

--- a/src/commands/propose.ts
+++ b/src/commands/propose.ts
@@ -5,7 +5,7 @@ import { resolvePayloadInput, initAptos } from '../utils.js';
 import chalk from 'chalk';
 import { proposeEntryFunction } from '../transactions.js';
 import { validateAddress, validateAsset } from '../validators.js';
-import { loadProfile } from '../profiles.js';
+import { loadProfile, validateProfileNetwork } from '../profiles.js';
 import {
   ensureMultisigAddressExists,
   ensureProfileExists,
@@ -63,8 +63,9 @@ Examples:
     .action(async (options: { payload: string; yes?: boolean }, cmd) => {
       const parentOptions = cmd.parent.opts();
       const multisig = await ensureMultisigAddressExists(parentOptions.multisigAddress);
+      const network = await ensureNetworkExists(parentOptions.network);
       const profile = await ensureProfileExists(parentOptions.profile);
-      const network = await ensureNetworkExists(parentOptions.network, parentOptions.profile);
+      validateProfileNetwork(profile, network);
 
       try {
         const jsonContent = await resolvePayloadInput(options.payload);
@@ -158,7 +159,9 @@ Examples:
       ) => {
         const parentOptions = cmd.parent.parent.opts();
         const multisig = await ensureMultisigAddressExists(parentOptions.multisigAddress);
+        const network = await ensureNetworkExists(parentOptions.network);
         const profile = await ensureProfileExists(parentOptions.profile);
+        validateProfileNetwork(profile, network);
 
         const entryFunction =
           options.asset.type === 'coin'
@@ -173,7 +176,6 @@ Examples:
                 functionArguments: [options.asset.address, options.recipient, options.amount],
               };
         try {
-          const network = await ensureNetworkExists(parentOptions.network, parentOptions.profile);
           const { signer, fullnode } = await loadProfile(profile, network);
           const aptos = initAptos(network, fullnode);
           await proposeEntryFunction(

--- a/src/commands/vote.ts
+++ b/src/commands/vote.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import { Command, Option } from 'commander';
 import { validateAddress, validateUInt, validateBool } from '../validators.js';
 import { signAndSubmitTransaction } from '../signing.js';
-import { loadProfile } from '../profiles.js';
+import { loadProfile, validateProfileNetwork } from '../profiles.js';
 import {
   ensureMultisigAddressExists,
   ensureProfileExists,
@@ -33,13 +33,15 @@ export const registerVoteCommand = (program: Command) => {
         profile?: string;
       }) => {
         try {
-          const network = await ensureNetworkExists(options.network, options.profile);
+          const network = await ensureNetworkExists(options.network);
+          const profile = await ensureProfileExists(options.profile);
+          validateProfileNetwork(profile, network);
           const hash = await handleVoteCommand(
             options.sequenceNumber,
             options.approve,
             await ensureMultisigAddressExists(options.multisigAddress),
             network,
-            await ensureProfileExists(options.profile)
+            profile
           );
           console.log(chalk.green(`Vote ok: ${getExplorerUrl(network, `txn/${hash}`)}`));
         } catch (error) {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -2,7 +2,6 @@ import { NetworkChoice } from './constants.js';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { getProfileNetwork } from './profiles.js';
 
 type Address = {
   alias: string;
@@ -155,32 +154,6 @@ export const ensureMultisigAddressExists = createEnsure(
   'No multisig address provided'
 );
 
-export async function ensureNetworkExists(
-  networkOption?: NetworkChoice,
-  profileOption?: string
-): Promise<NetworkChoice> {
-  // 1. CLI option
-  if (networkOption) {
-    return networkOption;
-  }
-
-  // 2. Infer from profile
-  const profileName = profileOption || (await ProfileDefault.get());
-  if (profileName) {
-    const network = getProfileNetwork(profileName);
-    if (network) {
-      return network;
-    }
-  }
-
-  // 3. Stored default
-  const storedNetwork = await NetworkDefault.get();
-  if (storedNetwork) {
-    return storedNetwork;
-  }
-
-  // 4. Hardcoded default
-  return 'aptos-mainnet';
-}
+export const ensureNetworkExists = createEnsure(NetworkDefault, 'No network provided');
 
 export const ensureProfileExists = createEnsure(ProfileDefault, 'No profile provided');


### PR DESCRIPTION
## Summary

Refactors the CLI API to use a **network-first design** where both `--network` and `--profile` are explicit, validated parameters. This eliminates ambiguity and ensures users cannot accidentally use mismatched profile/network combinations.

## Changes

### Core Logic
- **`src/storage.ts`**: Simplified `ensureNetworkExists()` to use `createEnsure` helper, removing hardcoded default and profile inference
- **`src/profiles.ts`**: Added `validateProfileNetwork()` to validate profile exists in correct config file and matches requested network

### Command Updates
- **Signing commands** (propose, vote, execute, account): Now validate profile/network consistency before loading
- **proposal command**: Removed `--profile` option (read-only command, doesn't need signing)

### Documentation
- **`docs.md`**: Regenerated to reflect new command signatures

## Benefits

1. **Explicit network choice**: Network is always intentional (via `--network` flag or stored default), never inferred
2. **Safety**: Validates that profile exists in correct config (`.aptos` vs `.movement`) and matches requested network
3. **Clear semantics**: `--network` = which blockchain, `--profile` = which identity
4. **Better errors**: Helpful messages show available profiles when validation fails

## Breaking Changes

- Network is now required (no hardcoded default to `aptos-mainnet`)
- Users must either pass `--network` or set a default with `safely default set --network <network>`
- Profile/network mismatches will error with clear validation messages

## Test plan

- [ ] Build succeeds with no TypeScript errors
- [ ] Commands with `--network` + `--profile` work correctly
- [ ] Commands with only `--network` (readonly) work correctly
- [ ] Validation errors show helpful messages for mismatches
- [ ] Defaults work correctly when set

🤖 Generated with [Claude Code](https://claude.com/claude-code)