### PR TITLE
Remove custom network support

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -37,7 +37,7 @@ Options:
   -o, --additional-owners <addresses>     Comma-separated list of additional owner addresses
   -n, --num-signatures-required <number>  Number of signatures required for execution
   -p, --profile <string>                  Profile to use for the transaction
-  --network <network>                     network to use (choices: "aptos-devnet", "aptos-testnet", "aptos-mainnet", "movement-mainnet", "movement-testnet", "custom")
+  --network <network>                     network to use (choices: "aptos-devnet", "aptos-testnet", "aptos-mainnet", "movement-mainnet", "movement-testnet")
   -h, --help                              display help for command
 ```
 
@@ -52,7 +52,7 @@ Options:
   -n, --num-signatures-required <number>  New number of signatures required for execution
   -m, --multisig-address <address>        multisig account address
   -p, --profile <string>                  Profile to use for the transaction
-  --network <network>                     network to use (choices: "aptos-devnet", "aptos-testnet", "aptos-mainnet", "movement-mainnet", "movement-testnet", "custom")
+  --network <network>                     network to use (choices: "aptos-devnet", "aptos-testnet", "aptos-mainnet", "movement-mainnet", "movement-testnet")
   -h, --help                              display help for command
 ```
 
@@ -65,9 +65,8 @@ Options:
   -m, --multisig-address <address>  multisig account address
   --network <network>               network to use (choices: "aptos-devnet",
                                     "aptos-testnet", "aptos-mainnet",
-                                    "movement-mainnet", "movement-testnet",
-                                    "custom")
-  --fullnode <url>                  Fullnode URL for custom network
+                                    "movement-mainnet", "movement-testnet")
+  --fullnode <url>                  Fullnode URL override
   -h, --help                        display help for command
 ```
 
@@ -80,8 +79,7 @@ Options:
   -m, --multisig-address <address>  multisig account address
   --network <network>               network to use (choices: "aptos-devnet",
                                     "aptos-testnet", "aptos-mainnet",
-                                    "movement-mainnet", "movement-testnet",
-                                    "custom")
+                                    "movement-mainnet", "movement-testnet")
   -p, --profile <string>            Profile to use for the transaction
   --no-simulate                     skip tx simulation
   -h, --help                        display help for command
@@ -139,8 +137,7 @@ Options:
   -m, --multisig-address <address>  multisig account address
   --network <network>               network to use (choices: "aptos-devnet",
                                     "aptos-testnet", "aptos-mainnet",
-                                    "movement-mainnet", "movement-testnet",
-                                    "custom")
+                                    "movement-mainnet", "movement-testnet")
   -p, --profile <string>            profile name of voter
   -h, --help                        display help for command
 ```
@@ -157,8 +154,7 @@ Options:
                                     it
   --network <network>               network to use (choices: "aptos-devnet",
                                     "aptos-testnet", "aptos-mainnet",
-                                    "movement-mainnet", "movement-testnet",
-                                    "custom")
+                                    "movement-mainnet", "movement-testnet")
   -h, --help                        display help for command
 ```
 
@@ -171,9 +167,8 @@ Options:
   -m, --multisig-address <address>  multisig account address
   --network <network>               network to use (choices: "aptos-devnet",
                                     "aptos-testnet", "aptos-mainnet",
-                                    "movement-mainnet", "movement-testnet",
-                                    "custom")
-  --fullnode <url>                  Fullnode URL for custom network
+                                    "movement-mainnet", "movement-testnet")
+  --fullnode <url>                  Fullnode URL override
   -s, --sequence-number <number>    fetch transaction with specific sequence
                                     number
   -h, --help                        display help for command
@@ -188,9 +183,8 @@ Options:
   -m, --multisig-address <address>  multisig account address
   --network <network>               network to use (choices: "aptos-devnet",
                                     "aptos-testnet", "aptos-mainnet",
-                                    "movement-mainnet", "movement-testnet",
-                                    "custom")
-  --fullnode <url>                  Fullnode URL for custom network
+                                    "movement-mainnet", "movement-testnet")
+  --fullnode <url>                  Fullnode URL override
   -s, --sequence-number <number>    fetch transaction with specific sequence
                                     number
   -h, --help                        display help for command
@@ -206,8 +200,8 @@ Options:
                        0x)
   --network <network>  network to use (choices: "aptos-devnet",
                        "aptos-testnet", "aptos-mainnet", "movement-mainnet",
-                       "movement-testnet", "custom")
-  --fullnode <url>     Fullnode URL for custom network
+                       "movement-testnet")
+  --fullnode <url>     Fullnode URL override
   -h, --help           display help for command
 ```
 
@@ -221,8 +215,8 @@ Options:
                        stdin)
   --network <network>  network to use (choices: "aptos-devnet",
                        "aptos-testnet", "aptos-mainnet", "movement-mainnet",
-                       "movement-testnet", "custom")
-  --fullnode <url>     Fullnode URL for custom network
+                       "movement-testnet")
+  --fullnode <url>     Fullnode URL override
   -h, --help           display help for command
 ```
 
@@ -302,7 +296,7 @@ Options:
   -m, --multisig <address>  Multisig address
   -n, --network <network>   network to use (choices: "aptos-devnet",
                             "aptos-testnet", "aptos-mainnet",
-                            "movement-mainnet", "movement-testnet", "custom")
+                            "movement-mainnet", "movement-testnet")
   -p, --profile <string>    Profile to use for transactions
   -h, --help                display help for command
 ```

--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -143,13 +143,7 @@ export const registerAccountCommand = (program: Command) => {
     .description('Show multisig summary')
     .option('-m, --multisig-address <address>', 'multisig account address', validateAddress)
     .addOption(new Option('--network <network>', 'network to use').choices(NETWORK_CHOICES))
-    .addOption(new Option('--fullnode <url>', 'Fullnode URL for custom network'))
-    .hook('preAction', (thisCommand) => {
-      const options = thisCommand.opts();
-      if (options.network === 'custom' && !options.fullnode) {
-        throw new Error('When using a "custom" network, you must provide a --fullnode URL.');
-      }
-    })
+    .addOption(new Option('--fullnode <url>', 'Fullnode URL override'))
     .action(
       async (options: { fullnode?: string; multisigAddress?: string; network?: NetworkChoice }) => {
         const network = await ensureNetworkExists(options.network);

--- a/src/commands/decode.ts
+++ b/src/commands/decode.ts
@@ -21,13 +21,7 @@ export function registerDecodeCommand(program: Command) {
       }
     )
     .addOption(new Option('--network <network>', 'network to use').choices(NETWORK_CHOICES))
-    .addOption(new Option('--fullnode <url>', 'Fullnode URL for custom network'))
-    .hook('preAction', (thisCommand) => {
-      const options = thisCommand.opts();
-      if (options.network === 'custom' && !options.fullnode) {
-        throw new Error('When using a "custom" network, you must provide a --fullnode URL.');
-      }
-    })
+    .addOption(new Option('--fullnode <url>', 'Fullnode URL override'))
     .action(async (options: { bytes: string; network: NetworkChoice; fullnode: string }) => {
       const network = await ensureNetworkExists(options.network);
       const aptos = initAptos(network, options.fullnode);

--- a/src/commands/encode.ts
+++ b/src/commands/encode.ts
@@ -14,26 +14,20 @@ export function registerEncodeCommand(program: Command) {
       'Transaction payload (file path, JSON string, or - for stdin)'
     )
     .addOption(new Option('--network <network>', 'network to use').choices(NETWORK_CHOICES))
-    .addOption(new Option('--fullnode <url>', 'Fullnode URL for custom network'))
+    .addOption(new Option('--fullnode <url>', 'Fullnode URL override'))
     .addHelpText(
       'after',
       `
 Examples:
   # From file
   $ safely encode --payload payload.json --network aptos-testnet
-  
+
   # Direct JSON string
   $ safely encode --payload '{"function_id":"0x1::coin::transfer","type_args":["0x1::aptos_coin::AptosCoin"],"args":["0x123",1000]}' --network aptos-testnet
-  
+
   # From stdin
   $ echo '{"function_id":"0x1::coin::transfer","type_args":["0x1::aptos_coin::AptosCoin"],"args":["0x123",1000]}' | safely encode --payload - --network aptos-testnet`
     )
-    .hook('preAction', (thisCommand) => {
-      const options = thisCommand.opts();
-      if (options.network === 'custom' && !options.fullnode) {
-        throw new Error('When using a "custom" network, you must provide a --fullnode URL.');
-      }
-    })
     .action(async (options: { payload: string; network: NetworkChoice; fullnode: string }) => {
       const network = await ensureNetworkExists(options.network);
       const aptos = initAptos(network, options.fullnode);

--- a/src/commands/proposal.ts
+++ b/src/commands/proposal.ts
@@ -11,13 +11,7 @@ export const registerProposalCommand = (program: Command) => {
     .description('List proposals for a multisig')
     .option('-m, --multisig-address <address>', 'multisig account address', validateAddress)
     .addOption(new Option('--network <network>', 'network to use').choices(NETWORK_CHOICES))
-    .addOption(new Option('--fullnode <url>', 'Fullnode URL for custom network'))
-    .hook('preAction', (thisCommand) => {
-      const options = thisCommand.opts();
-      if (options.network === 'custom' && !options.fullnode) {
-        throw new Error('When using a "custom" network, you must provide a --fullnode URL.');
-      }
-    })
+    .addOption(new Option('--fullnode <url>', 'Fullnode URL override'))
     .option(
       '-s, --sequence-number <number>',
       'fetch transaction with specific sequence number',

--- a/src/commands/simulate.ts
+++ b/src/commands/simulate.ts
@@ -15,13 +15,7 @@ export const registerSimulateCommand = (program: Command) => {
     .description('Simulate multisig transaction')
     .option('-m, --multisig-address <address>', 'multisig account address', validateAddress)
     .addOption(new Option('--network <network>', 'network to use').choices(NETWORK_CHOICES))
-    .addOption(new Option('--fullnode <url>', 'Fullnode URL for custom network'))
-    .hook('preAction', (thisCommand) => {
-      const options = thisCommand.opts();
-      if (options.network === 'custom' && !options.fullnode) {
-        throw new Error('When using a "custom" network, you must provide a --fullnode URL.');
-      }
-    })
+    .addOption(new Option('--fullnode <url>', 'Fullnode URL override'))
     .requiredOption(
       '-s, --sequence-number <number>',
       'fetch transaction with specific sequence number',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,7 +4,6 @@ export const NETWORK_CHOICES = [
   'aptos-mainnet',
   'movement-mainnet',
   'movement-testnet',
-  'custom',
 ] as const;
 
 export type NetworkChoice = (typeof NETWORK_CHOICES)[number];

--- a/src/ui/HomeView.tsx
+++ b/src/ui/HomeView.tsx
@@ -137,7 +137,7 @@ const HomeView: React.FC<HomeViewProps> = ({ onNavigate }) => {
     filteredProfiles.some(p => p.name === config.profile)
   );
 
-  const networks = NETWORK_CHOICES.filter(n => n !== 'custom');
+  const networks = NETWORK_CHOICES;
 
   // Menu actions
   const updateConfig = useCallback(async (updates: Partial<Config>) => {
@@ -181,7 +181,7 @@ const HomeView: React.FC<HomeViewProps> = ({ onNavigate }) => {
     const updates: Partial<MenuState> = { expandedItem: item };
 
     if (item === 'network') {
-      const idx = config.network && config.network !== 'custom'
+      const idx = config.network
         ? networks.indexOf(config.network as any)
         : -1;
       updates.subIndex = Math.max(0, idx);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,8 +22,6 @@ export function getFullnodeUrl(network: NetworkChoice): string {
       return 'https://rpc.sentio.xyz/movement/v1';
     case 'movement-testnet':
       return 'https://full.testnet.movementinfra.xyz/v1';
-    case 'custom':
-      throw new Error('Custom network requires an explicit fullnode URL');
     default:
       throw new Error(`Unknown network: ${network}`);
   }
@@ -58,7 +56,7 @@ export function getExplorerUrl(network: NetworkChoice, path: string): string {
       case 'movement-testnet':
         return 'testnet';
       default:
-        return 'custom';
+        throw new Error(`Unknown network: ${network}`);
     }
   })();
 


### PR DESCRIPTION
## Summary
- Remove the 'custom' network option from NETWORK_CHOICES
- Remove validation hooks requiring --fullnode for custom network
- Update --fullnode option descriptions to indicate it's a URL override for any supported network
- Fix TypeScript errors in HomeView.tsx related to custom network filtering

## Test plan
- [x] Build passes (`pnpm build`)
- [ ] All network commands work with supported networks (aptos-devnet, aptos-testnet, aptos-mainnet, movement-mainnet, movement-testnet)
- [ ] --fullnode flag still allows overriding URLs for supported networks

🤖 Generated with [Claude Code](https://claude.com/claude-code)