### PR TITLE
Reorganize README to emphasize interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,6 @@
 
 Manage your multisig accounts on Aptos & Movement **safely** through a secure CLI interface.
 
-## Why safely?
-
-In the wake of recent security incidents like the [SafeWallet frontend compromise](https://x.com/safe/status/1894768522720350673), it's become clear that web-based multisig interfaces pose significant risks. Web frontends can be modified by attackers, making transaction verification difficult or impossible for users. **safely** takes a different approach:
-
-- **CLI-first**: No web frontend means no risk of compromised interfaces
-- **Verifiable**: All transactions are transparent and can be inspected directly
-- **Local execution**: Your keys stay on your machine
-
 ## Quickstart
 
 1. Install the CLI:
@@ -18,29 +10,36 @@ In the wake of recent security incidents like the [SafeWallet frontend compromis
 npm install -g @thalalabs/safely
 ```
 
-2. Under a directory where you have your aptos profiles configured, view pending transactions of a multisig account:
+2. Configure your Aptos profile (if not already done):
 
 ```bash
-safely proposal -m <multisig_address> -p <profile_name>
+aptos init --profile <profile_name>
+# or with Ledger hardware wallet
+aptos init --ledger --profile <profile_name>
 ```
 
-Aptos profile can be configured by running `aptos init --profile <profile_name>` or `aptos init --ledger --profile <profile_name>` ([docs](https://aptos.dev/en/build/cli/trying-things-on-chain/ledger)).
+See [Aptos CLI docs](https://aptos.dev/en/build/cli/trying-things-on-chain/ledger) for more details.
 
-3. Follow the terminal UI to view transaction details, vote yes, vote no, or execute the transaction once vote threshold is met.
+3. Launch the interactive terminal UI:
 
-See [docs.md](./docs.md) for detailed documentation.
+```bash
+safely
+```
 
-## Key Features
+The interactive mode will guide you through:
 
-- **Security First**: CLI-based interface eliminates frontend security risks
-- **Transaction Simulation**: Display simulation results wherever possible
-- **Human-Readable**: Clear transaction descriptions and parameter explanations
-- **Open Source**: Community-driven development and quick iterations
-- **Multi-Chain**: Support for both Aptos and Movement
-- **Hardware Security**: Native Ledger support
-- **Local Control**: All operations run locally on your machine
+- Selecting or entering a multisig address
+- Choosing your profile for signing
+- Viewing pending proposals
+- Voting on or executing transactions
 
-## Usage
+**This is the recommended way to use safely** - it provides a safe, guided experience with clear transaction details and simulation results.
+
+For advanced usage and automation, see the [Subcommands](#subcommands) section below.
+
+## Subcommands
+
+**Note**: The interactive mode (`safely` without arguments) is the recommended way to interact with multisig accounts. Subcommands are provided for advanced users who need automation or scripting capabilities.
 
 ```bash
 > safely --help
@@ -67,7 +66,7 @@ Commands:
   help [command]      display help for command
 ```
 
-For detailed usage instructions and examples, see [docs.md](./docs.md).
+For detailed subcommand documentation and examples, see [docs.md](./docs.md).
 
 ## Development
 
@@ -114,6 +113,19 @@ We welcome contributions from the entire Move ecosystem! Whether you're:
 - A user reporting issues or suggesting features
 
 Your input helps make multisig management safer and more efficient for everyone.
+
+## Why safely?
+
+In the wake of recent security incidents like the [SafeWallet frontend compromise](https://x.com/safe/status/1894768522720350673), it's become clear that web-based multisig interfaces pose significant risks. Web frontends can be modified by attackers, making transaction verification difficult or impossible for users. **safely** takes a different approach:
+
+- **CLI-first**: No web frontend means no risk of compromised interfaces
+- **Verifiable**: All transactions are transparent and can be inspected directly
+- **Local Control**: All operations run locally on your machine
+- **Transaction Simulation**: Display simulation results wherever possible
+- **Human-Readable**: Clear transaction descriptions and parameter explanations
+- **Multi-Chain**: Support for both Aptos and Movement
+- **Hardware Security**: Native Ledger support
+- **Open Source**: Community-driven development and quick iterations
 
 ## License
 


### PR DESCRIPTION
## Summary

- Moved Quickstart to the top with interactive mode (`safely`) as the primary usage pattern
- Renamed "Usage" section to "Subcommands" with a clear note that they're for advanced users and automation
- Moved "Why safely?" section to the end and merged it with "Key Features" 
- Reordered sections to prioritize what users need first: Quickstart → Subcommands → Development → Community → Why safely → License

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm the quickstart instructions are clear and actionable
- [ ] Check that all internal links work properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)