### PR TITLE
Add RPC endpoint display to TUI

### DIFF
--- a/src/ui/ProposalView.tsx
+++ b/src/ui/ProposalView.tsx
@@ -15,7 +15,7 @@ import {
   safeStringify
 } from '../utils.js';
 import { InputEntryFunctionData } from '@aptos-labs/ts-sdk';
-import { initAptos, getExplorerUrl } from '../utils.js';
+import { initAptos, getExplorerUrl, getFullnodeUrl } from '../utils.js';
 import { NetworkChoice } from '../constants.js';
 import { handleExecuteCommand } from '../commands/execute.js';
 import { handleVoteCommand } from '../commands/vote.js';
@@ -112,6 +112,7 @@ const ProposalView: React.FC<ProposalViewProps> = ({
   const [signaturesRequired, setSigRequired] = useState<number>(0);
   const [signerAddress, setSignerAddress] = useState<string>('');
   const [aptos, setAptos] = useState<Aptos | null>(null);
+  const [rpcEndpoint, setRpcEndpoint] = useState<string | undefined>(undefined);
 
   // Initialize
   useEffect(() => {
@@ -132,6 +133,8 @@ const ProposalView: React.FC<ProposalViewProps> = ({
 
         const aptosInstance = initAptos(network as NetworkChoice, fullnodeUrl);
         setAptos(aptosInstance);
+        // Always set the actual RPC endpoint - either custom or default
+        setRpcEndpoint(fullnodeUrl || getFullnodeUrl(network as NetworkChoice));
 
         // Get multisig info
         const [[ownersResult], [sigRequired]] = await Promise.all([
@@ -375,6 +378,7 @@ const ProposalView: React.FC<ProposalViewProps> = ({
         network={network}
         profile={profile}
         multisig={multisigAddress}
+        rpcEndpoint={rpcEndpoint}
       />
 
       {/* Content Area */}

--- a/src/ui/SharedHeader.tsx
+++ b/src/ui/SharedHeader.tsx
@@ -6,9 +6,10 @@ interface SharedHeaderProps {
   network?: string;
   profile?: string;
   multisig?: string;
+  rpcEndpoint?: string;
 }
 
-const SharedHeader: React.FC<SharedHeaderProps> = ({ network, profile, multisig }) => {
+const SharedHeader: React.FC<SharedHeaderProps> = ({ network, profile, multisig, rpcEndpoint }) => {
 
   return (
     <>
@@ -45,6 +46,11 @@ const SharedHeader: React.FC<SharedHeaderProps> = ({ network, profile, multisig 
           <Text>
             Profile: {profile ? (
               <Text color="green">{profile}</Text>
+            ) : <Text color="red">Not set</Text>}
+          </Text>
+          <Text>
+            RPC: {rpcEndpoint ? (
+              <Text color="green">{rpcEndpoint}</Text>
             ) : <Text color="red">Not set</Text>}
           </Text>
         </Box>


### PR DESCRIPTION
## Summary
- Added RPC endpoint display to the SharedHeader component in the TUI
- The RPC URL is now shown at the bottom of the Connection section
- Always displays the actual fullnode URL (either custom from profile or network default)
- Uses consistent formatting with other connection fields (green when set, red when not set)

## Changes
- **SharedHeader.tsx**: Added `rpcEndpoint` prop and display logic
- **ProposalView.tsx**: Computes actual RPC URL and passes to SharedHeader
- **HomeView.tsx**: Loads RPC from profile or uses network default and passes to SharedHeader

## Test plan
- [ ] Verify RPC endpoint displays correctly in interactive mode
- [ ] Check that custom RPC URLs from profiles are shown
- [ ] Confirm default network RPC URLs are displayed when no custom URL is set
- [ ] Test that "Not set" appears in red when network is not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)