### PR TITLE
Add loading spinner to SharedHeader and fix RPC flash

### DIFF
--- a/src/ui/HomeView.tsx
+++ b/src/ui/HomeView.tsx
@@ -43,6 +43,7 @@ interface MultisigResource {
 const HomeView: React.FC<HomeViewProps> = ({ onNavigate }) => {
   const { exit } = useApp();
   const [view, setView] = useState<'home' | 'proposal'>('home');
+  const [isLoading, setIsLoading] = useState(true);
   const [config, setConfig] = useState<Config>({
     profiles: [],
     multisigOwners: [],
@@ -77,6 +78,7 @@ const HomeView: React.FC<HomeViewProps> = ({ onNavigate }) => {
         profileAddress: null,
         multisigHistory
       });
+      setIsLoading(false);
     };
     load();
   }, []);
@@ -347,12 +349,13 @@ const HomeView: React.FC<HomeViewProps> = ({ onNavigate }) => {
   });
 
   // Show proposal view
-  if (view === 'proposal' && canAccessProposals && config.network) {
+  if (view === 'proposal' && canAccessProposals) {
     return (
       <ProposalView
         profile={config.profile}
         multisigAddress={config.multisig!}
-        network={config.network}
+        network={config.network!}
+        rpcEndpoint={config.rpcEndpoint}
         onBack={() => setView('home')}
       />
     );
@@ -367,6 +370,7 @@ const HomeView: React.FC<HomeViewProps> = ({ onNavigate }) => {
         profile={config.profile}
         multisig={config.multisig}
         rpcEndpoint={config.rpcEndpoint}
+        isLoading={isLoading}
       />
 
       <Box borderStyle="single" paddingX={1}>

--- a/src/ui/ProposalView.tsx
+++ b/src/ui/ProposalView.tsx
@@ -15,7 +15,7 @@ import {
   safeStringify
 } from '../utils.js';
 import { InputEntryFunctionData } from '@aptos-labs/ts-sdk';
-import { initAptos, getExplorerUrl, getFullnodeUrl } from '../utils.js';
+import { initAptos, getExplorerUrl } from '../utils.js';
 import { NetworkChoice } from '../constants.js';
 import { handleExecuteCommand } from '../commands/execute.js';
 import { handleVoteCommand } from '../commands/vote.js';
@@ -68,7 +68,7 @@ function formatFunctionId(functionId: string): string {
 interface ProposalViewProps {
   multisigAddress: string;
   network: string;
-  fullnode?: string;
+  rpcEndpoint?: string;
   profile?: string;
   sequenceNumber?: number;
   onBack?: () => void;
@@ -95,7 +95,7 @@ interface ProposalData {
 const ProposalView: React.FC<ProposalViewProps> = ({
   multisigAddress,
   network,
-  fullnode,
+  rpcEndpoint,
   profile,
   sequenceNumber,
   onBack
@@ -112,29 +112,23 @@ const ProposalView: React.FC<ProposalViewProps> = ({
   const [signaturesRequired, setSigRequired] = useState<number>(0);
   const [signerAddress, setSignerAddress] = useState<string>('');
   const [aptos, setAptos] = useState<Aptos | null>(null);
-  const [rpcEndpoint, setRpcEndpoint] = useState<string | undefined>(undefined);
 
   // Initialize
   useEffect(() => {
     const init = async () => {
       try {
-        let fullnodeUrl = fullnode;
-
         // Load profile if provided
         if (profile) {
           const profileData = await loadProfile(profile, network as NetworkChoice);
           const { signer } = profileData;
           setSignerAddress(signer.accountAddress.toString());
-          fullnodeUrl = fullnodeUrl || profileData.fullnode;
         } else {
           // Read-only mode - no profile
           setSignerAddress('');
         }
 
-        const aptosInstance = initAptos(network as NetworkChoice, fullnodeUrl);
+        const aptosInstance = initAptos(network as NetworkChoice, rpcEndpoint);
         setAptos(aptosInstance);
-        // Always set the actual RPC endpoint - either custom or default
-        setRpcEndpoint(fullnodeUrl || getFullnodeUrl(network as NetworkChoice));
 
         // Get multisig info
         const [[ownersResult], [sigRequired]] = await Promise.all([

--- a/src/ui/SharedHeader.tsx
+++ b/src/ui/SharedHeader.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Box, Text } from 'ink';
+import Spinner from 'ink-spinner';
 
 interface SharedHeaderProps {
   subtitle?: string;
@@ -7,9 +8,10 @@ interface SharedHeaderProps {
   profile?: string;
   multisig?: string;
   rpcEndpoint?: string;
+  isLoading?: boolean;
 }
 
-const SharedHeader: React.FC<SharedHeaderProps> = ({ network, profile, multisig, rpcEndpoint }) => {
+const SharedHeader: React.FC<SharedHeaderProps> = ({ network, profile, multisig, rpcEndpoint, isLoading = false }) => {
 
   return (
     <>
@@ -34,22 +36,30 @@ const SharedHeader: React.FC<SharedHeaderProps> = ({ network, profile, multisig,
         <Box flexDirection="column">
           <Text bold>Connection:</Text>
           <Text>
-            Network: {network ? (
+            Network: {isLoading ? (
+              <Text color="cyan"><Spinner type="dots" /> Loading...</Text>
+            ) : network ? (
               <Text color="green">{network}</Text>
             ) : <Text color="red">Not set</Text>}
           </Text>
           <Text>
-            Multisig: {multisig ? (
+            Multisig: {isLoading ? (
+              <Text color="cyan"><Spinner type="dots" /> Loading...</Text>
+            ) : multisig ? (
               <Text color="green">{multisig.slice(0, 10)}...</Text>
             ) : <Text color="red">Not set</Text>}
           </Text>
           <Text>
-            Profile: {profile ? (
+            Profile: {isLoading ? (
+              <Text color="cyan"><Spinner type="dots" /> Loading...</Text>
+            ) : profile ? (
               <Text color="green">{profile}</Text>
             ) : <Text color="red">Not set</Text>}
           </Text>
           <Text>
-            RPC: {rpcEndpoint ? (
+            RPC: {isLoading ? (
+              <Text color="cyan"><Spinner type="dots" /> Loading...</Text>
+            ) : rpcEndpoint ? (
               <Text color="green">{rpcEndpoint}</Text>
             ) : <Text color="red">Not set</Text>}
           </Text>


### PR DESCRIPTION
## Summary
- Add loading spinner to SharedHeader during initial data load
- Fix RPC endpoint flash when entering ProposalView
- Simplify ProposalView by passing RPC endpoint from parent

## Changes

### 1. SharedHeader loading state
- Added `isLoading` prop to show spinner during initial config load
- Better UX: users see loading indicators instead of "Not set" errors
- Only used in HomeView (not ProposalView, since values already loaded)

### 2. Fixed RPC flash in ProposalView
**Problem**: When entering proposals view, RPC field flashed from "Not set" (red) → URL (green)

**Root cause**: ProposalView maintained its own `rpcEndpoint` state initialized to `undefined`, causing async update after mount

**Solution**:
- Pass `rpcEndpoint` from HomeView to ProposalView as prop
- Remove async state management in ProposalView
- Rename prop from `fullnode` → `rpcEndpoint` for clarity
- ProposalView receives already-computed value → no flash

### 3. Code cleanup
- Removed redundant `&& config.network` check (already guaranteed by `canAccessProposals`)
- ProposalView no longer computes or loads RPC endpoint - just receives and displays it
- Removed unused `getFullnodeUrl` import from ProposalView

## Test plan
- [x] Build passes
- [x] Format passes
- [ ] Manual test: Start app, verify spinner shows during load
- [ ] Manual test: Enter proposals view, verify no RPC flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)