### PR TITLE
Add support for Option<address> in raw payload format

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -22,7 +22,8 @@ Options:
   -h, --help        display help for command
 Commands:
   create [options]  Create a new multisig account
-  update [options]  Update multisig owners and optionally the number of required signatures
+  update [options]  Update multisig owners and optionally the number of
+                    required signatures
   show [options]    Show multisig summary
   help [command]    display help for command
 ```
@@ -62,7 +63,9 @@ Show multisig summary
 ```
 Options:
   -m, --multisig-address <address>  multisig account address
-  --network <network>               network to use (choices: "aptos-devnet", "aptos-testnet", "aptos-mainnet", "movement-mainnet", "movement-testnet")
+  --network <network>               network to use (choices: "aptos-devnet",
+                                    "aptos-testnet", "aptos-mainnet",
+                                    "movement-mainnet", "movement-testnet")
   --fullnode <url>                  Fullnode URL override
   -h, --help                        display help for command
 ```
@@ -74,12 +77,15 @@ Propose a new transaction for a multisig
 ```
 Options:
   -m, --multisig-address <address>  multisig account address
-  --network <network>               network to use (choices: "aptos-devnet", "aptos-testnet", "aptos-mainnet", "movement-mainnet", "movement-testnet")
+  --network <network>               network to use (choices: "aptos-devnet",
+                                    "aptos-testnet", "aptos-mainnet",
+                                    "movement-mainnet", "movement-testnet")
   -p, --profile <string>            Profile to use for the transaction
   --no-simulate                     skip tx simulation
   -h, --help                        display help for command
 Commands:
-  raw [options]                     Propose a raw transaction from a payload file (supports batch payloads)
+  raw [options]                     Propose a raw transaction from a payload
+                                    file (supports batch payloads)
   predefined                        Propose a predefined transaction type
   help [command]                    display help for command
 ```
@@ -90,7 +96,8 @@ Propose a raw transaction from a payload file (supports batch payloads)
 
 ```
 Options:
-  --payload <payload>  Transaction payload (JSON/YAML file path, JSON string, or - for stdin)
+  --payload <payload>  Transaction payload (JSON/YAML file path, JSON string,
+                       or - for stdin)
   --yes                Skip confirmation prompt for batch payloads
   -h, --help           display help for command
 ```
@@ -128,7 +135,9 @@ Options:
   -s, --sequence-number <number>    sequence number of transaction to vote on
   -a, --approve <boolean>           true to approve, false to reject
   -m, --multisig-address <address>  multisig account address
-  --network <network>               network to use (choices: "aptos-devnet", "aptos-testnet", "aptos-mainnet", "movement-mainnet", "movement-testnet")
+  --network <network>               network to use (choices: "aptos-devnet",
+                                    "aptos-testnet", "aptos-mainnet",
+                                    "movement-mainnet", "movement-testnet")
   -p, --profile <string>            profile name of voter
   -h, --help                        display help for command
 ```
@@ -141,8 +150,11 @@ Execute a multisig transaction
 Options:
   -m, --multisig-address <address>  multisig account address
   -p, --profile <string>            Profile to use for the transaction
-  --reject                          Reject the transaction instead of executing it
-  --network <network>               network to use (choices: "aptos-devnet", "aptos-testnet", "aptos-mainnet", "movement-mainnet", "movement-testnet")
+  --reject                          Reject the transaction instead of executing
+                                    it
+  --network <network>               network to use (choices: "aptos-devnet",
+                                    "aptos-testnet", "aptos-mainnet",
+                                    "movement-mainnet", "movement-testnet")
   -h, --help                        display help for command
 ```
 
@@ -153,9 +165,12 @@ List proposals for a multisig
 ```
 Options:
   -m, --multisig-address <address>  multisig account address
-  --network <network>               network to use (choices: "aptos-devnet", "aptos-testnet", "aptos-mainnet", "movement-mainnet", "movement-testnet")
+  --network <network>               network to use (choices: "aptos-devnet",
+                                    "aptos-testnet", "aptos-mainnet",
+                                    "movement-mainnet", "movement-testnet")
   --fullnode <url>                  Fullnode URL override
-  -s, --sequence-number <number>    fetch transaction with specific sequence number
+  -s, --sequence-number <number>    fetch transaction with specific sequence
+                                    number
   -h, --help                        display help for command
 ```
 
@@ -166,9 +181,12 @@ Simulate multisig transaction
 ```
 Options:
   -m, --multisig-address <address>  multisig account address
-  --network <network>               network to use (choices: "aptos-devnet", "aptos-testnet", "aptos-mainnet", "movement-mainnet", "movement-testnet")
+  --network <network>               network to use (choices: "aptos-devnet",
+                                    "aptos-testnet", "aptos-mainnet",
+                                    "movement-mainnet", "movement-testnet")
   --fullnode <url>                  Fullnode URL override
-  -s, --sequence-number <number>    fetch transaction with specific sequence number
+  -s, --sequence-number <number>    fetch transaction with specific sequence
+                                    number
   -h, --help                        display help for command
 ```
 
@@ -178,8 +196,11 @@ Decode multisig transaction bytes (experimental)
 
 ```
 Options:
-  -b, --bytes <bytes>  transaction bytes to decode (hex string starting with 0x)
-  --network <network>  network to use (choices: "aptos-devnet", "aptos-testnet", "aptos-mainnet", "movement-mainnet", "movement-testnet")
+  -b, --bytes <bytes>  transaction bytes to decode (hex string starting with
+                       0x)
+  --network <network>  network to use (choices: "aptos-devnet",
+                       "aptos-testnet", "aptos-mainnet", "movement-mainnet",
+                       "movement-testnet")
   --fullnode <url>     Fullnode URL override
   -h, --help           display help for command
 ```
@@ -190,8 +211,11 @@ Encode entry function payload (experimental)
 
 ```
 Options:
-  --payload <payload>  Transaction payload (file path, JSON string, or - for stdin)
-  --network <network>  network to use (choices: "aptos-devnet", "aptos-testnet", "aptos-mainnet", "movement-mainnet", "movement-testnet")
+  --payload <payload>  Transaction payload (file path, JSON string, or - for
+                       stdin)
+  --network <network>  network to use (choices: "aptos-devnet",
+                       "aptos-testnet", "aptos-mainnet", "movement-mainnet",
+                       "movement-testnet")
   --fullnode <url>     Fullnode URL override
   -h, --help           display help for command
 ```
@@ -270,7 +294,9 @@ Set default multisig values
 ```
 Options:
   -m, --multisig <address>  Multisig address
-  -n, --network <network>   network to use (choices: "aptos-devnet", "aptos-testnet", "aptos-mainnet", "movement-mainnet", "movement-testnet")
+  -n, --network <network>   network to use (choices: "aptos-devnet",
+                            "aptos-testnet", "aptos-mainnet",
+                            "movement-mainnet", "movement-testnet")
   -p, --profile <string>    Profile to use for transactions
   -h, --help                display help for command
 ```


### PR DESCRIPTION
## Summary
- Add support for `Option<address>` type in raw payload transaction arguments
- Handle both `None` (empty/null value) and `Some(address)` cases using `MoveOption<AccountAddress>` from Aptos SDK

## Changes
- `src/entryFunction.ts`: Add special handling for `0x1::option::Option<address>` argument types
  - Empty/null values are converted to `new MoveOption<AccountAddress>()` (None)
  - Valid address strings are converted to `new MoveOption<AccountAddress>(AccountAddress.from(value))` (Some)

## Test plan
- [ ] Test proposing a transaction with Option<address> argument set to None
- [ ] Test proposing a transaction with Option<address> argument set to Some(valid_address)
- [ ] Verify transaction simulation succeeds for both cases
- [ ] Verify execution works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)