### PR TITLE
Restore hex argument decoding in parseSinglePayload

### DIFF
--- a/src/entryFunction.ts
+++ b/src/entryFunction.ts
@@ -50,17 +50,41 @@ function parseSinglePayload(content: {
     throw new Error('args must be an array');
   }
 
-  // Extract function arguments (just the values)
-  const functionArguments = content.args.map((arg) => {
-    if (!arg.type || arg.value === undefined) {
-      throw new Error(`Invalid argument format: ${JSON.stringify(arg)}`);
+  // Explicitly handle hex args (which must be cast to vector<u8> or vector<vector<u8>> types)
+  // This is to handle payload file such as 0x1::code::publish_package_txn
+  const hexDecodedArgs = content.args.map((arg) => {
+    // Hex args need to be decoded into vector<u8> equivalents
+    if (arg.type === 'hex') {
+      // vector<u8>
+      if (typeof arg.value === 'string') {
+        return hexToBytes(arg.value);
+      }
+
+      // vector<vector<u8>>
+      if (Array.isArray(arg.value) && arg.value.every((v) => typeof v === 'string')) {
+        return arg.value.map((hexStr) => hexToBytes(hexStr));
+      }
     }
+
     return arg.value;
   });
 
   return {
     function: content.function_id as MoveFunctionId,
     typeArguments: content.type_args,
-    functionArguments,
+    functionArguments: hexDecodedArgs,
   };
+}
+
+function hexToBytes(hexString: string) {
+  // Remove "0x" prefix if present
+  if (hexString.startsWith('0x')) {
+    hexString = hexString.slice(2);
+  }
+
+  const matched = hexString.match(/.{1,2}/g);
+  if (!matched) return new Uint8Array(); // Return an empty Uint8Array if no match
+
+  // Convert hex to byte array
+  return new Uint8Array(matched.map((byte) => parseInt(byte, 16)));
 }


### PR DESCRIPTION
Fixes bug introduced in a7d794a where hex-typed arguments were not being decoded to Uint8Array, causing Move abort errors during transaction simulation.

The cleanup commit removed critical hex decoding logic that converts hex strings to byte arrays for vector<u8> and vector<vector<u8>> arguments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)