### PR TITLE
fix: show correct message for batch dry-run

### DIFF
--- a/.changeset/many-needles-give.md
+++ b/.changeset/many-needles-give.md
@@ -1,0 +1,5 @@
+---
+'@thalalabs/safely': patch
+---
+
+fix small ui bug

--- a/.changeset/social-bees-begin.md
+++ b/.changeset/social-bees-begin.md
@@ -1,5 +1,0 @@
----
-'@thalalabs/safely': patch
----
-
-fix movement previewnet support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @thalalabs/safely
 
+## 0.4.5
+
+### Patch Changes
+
+- 768e4ed: fix movement previewnet support
+
 ## 0.4.4
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@thalalabs/safely",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "main": "index.js",
   "bin": {
     "safely": "./dist/index.js"

--- a/src/commands/propose.ts
+++ b/src/commands/propose.ts
@@ -116,7 +116,13 @@ Examples:
             }
           }
 
-          console.log(chalk.green(`\nSuccessfully proposed all ${payloads.length} transactions.`));
+          if (parentOptions.dryRun) {
+            console.log(chalk.green(`\nDry run complete for all ${payloads.length} transactions.`));
+          } else {
+            console.log(
+              chalk.green(`\nSuccessfully proposed all ${payloads.length} transactions.`)
+            );
+          }
         } else {
           // Single payload - use existing logic
           const entryFunction = parseEntryFunctionPayload(jsonContent);


### PR DESCRIPTION
## Summary
- Fix misleading success message when using `--dry-run` with batch payloads
- Now correctly shows "Dry run complete for all X transactions" instead of "Successfully proposed all X transactions"

## Test plan
- [ ] Run `safely propose raw --payload batch.yaml --dry-run` and verify correct message is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)